### PR TITLE
Small changes on LIP template

### DIFF
--- a/lip-X.md
+++ b/lip-X.md
@@ -4,7 +4,7 @@ title: <LIP title>
 author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
 discussions-to: <URL>
 status: Draft
-type: <Standards Track (Core, Networking, Interface, ERC)  | Informational | Meta>
+type: <Standards Track (Core, Networking, Interface, LRC)  | Informational | Meta>
 category (*only required for Standard Track): <Core | Interface | LSP>
 created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 requires (*optional): <LIP number(s)>
@@ -27,8 +27,8 @@ If you can't explain it simply, you don't understand it well enough." Provide a 
 A short (~200 word) description of the technical issue being addressed.
 
 ## Motivation
-<!--The motivation is critical for LIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
-The motivation is critical for LIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.
+<!--The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
+The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->

--- a/lip-X.md
+++ b/lip-X.md
@@ -4,7 +4,7 @@ title: <LIP title>
 author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
 discussions-to: <URL>
 status: Draft
-type: <Standards Track (Core, Networking, Interface, LRC)  | Informational | Meta>
+type: <Standards Track (Core, Networking, Interface, LSP)  | Informational | Meta>
 category (*only required for Standard Track): <Core | Interface | LSP>
 created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 requires (*optional): <LIP number(s)>


### PR DESCRIPTION
I fixed some of the references of Ethereum in the LIP template.

There're still some in the `specification` section that I don't know if we should change.