### PR TITLE
Adjust length of "hashFunction" string

### DIFF
--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -101,7 +101,7 @@ let json = JSON.stringify({
     }
 })
 
-let hashFunction = web3.utils.keccak256('keccak256(utf8)').substr(0, 8)
+let hashFunction = web3.utils.keccak256('keccak256(utf8)').substr(0, 10)
 > '0x6f357c6a'
 
 let hash = web3.utils.keccak256(json)


### PR DESCRIPTION
While experimenting with erc725.js I realized it never recognized the hashFunction