### PR TITLE
Add extra LSP6 Key, fix Errors on LSP2 and 6 + disable Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Disable prettier on any Markdown file
+*.md

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -9,6 +9,7 @@ created: 2020-07-01
 requires: ERC725Y
 ---
 
+
 ## Simple Summary
 
 This schema describes how a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key values can be described.
@@ -20,48 +21,49 @@ This schema allows to standardize the key values that can be used in ERC725Y sub
 
 ## Motivation
 
-This schema defines a way to make those key values automatically parsable, so a interface or smart contract knows how to read and interact with them.
+This schema defines a way to make those key values automatically parsable, so a interface or smart contract knows how to read and interact with them. 
 
 This schema is for example used in [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) based smart contracts like
 [LSP3-UniversalProfile](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md) and [LSP4-DigitalCertificate](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-4-DigitalCertificate.md).
 
+
 ## Specification
 
-To make ERC725Y keys readable we define the following key value types:  
+To make ERC725Y keys readable we define the following key value types:   
 (Note: this set is not complete yet, and should be extended over time)
 
 - `name`: Describes the name of the key, SHOULD compromise of the Standards name + sub type. e.g: `LSP2Name`
 - `key`: the keccak256 hash of the name. This is the actual key that MUST be retrievable via `ERC725Y.getData(bytes32 key)`. e.g: `keccack256('LSP2Name') = 0xf9e26448acc9f20625c059a95279675b8f58ba4f06d262f83a32b4dd35dee019`
 - `keyType`: Types that determine how the values should be interpreted. Valid types are:
-  - [`Singleton`](#singleton): A simple key.
-  - [`Array`](#array): An array spanning multiple ERC725Y keys.
-  - [`Mapping`](#mapping): A key that maps two words.
-  - [`AddressMapping`](#addressmapping): A key that maps a word to an address.
-  - [`AddressMappingWithGrouping`](#addressmappingwithgrouping): A key that maps a word, to a grouping word to an address.
-  - `valueType`: The type the content MUST be decoded with.
-  - `string`: The bytes are a UTF8 encoded string
-  - `address`: The bytes are an 20 bytes address
-  - `uint256`: The bytes are a uint256
-  - `bytes32`: The bytes are a 32 bytes
-  - `bytes`: The bytes are a bytes
-  - `string[]`: The bytes are a UTF8 encoded string array
-  - `address[]`: The bytes are an 20 bytes address array
-  - `uint256[]`: The bytes are a uint256 array
-  - `bytes[]`: The bytes are a bytes array
-  - `bytesN[]`: The bytes are a N bytes
-  - `valueContent`: The content in the returned value. Valid values are:
-  - `Bytes`: The content are bytes.
-  - `BytesN`: The content are bytes with length N.
-  - `Number`: The content is a number.
-  - `String`: The content is a UTF8 string.
-  - `Address`: The content is an address.
-  - `Keccak256`: The content is an keccak256 32 bytes hash.
-  - [`AssetURL`](#asseturl): The content contains the hash function, hash and link to the asset file.
-  - [`JSONURL`](#jsonurl): The content contains the hash function, hash and link to the JSON file.
-  - `URL`: The content is an URL encoded as UTF8 string.
-  - `Markdown`: The content is structured Markdown mostly encoded as UTF8 string.
-  - `0x1345ABCD...`: If the value content are specific bytes, than the returned value is expected to equal those bytes.
-
+    - [`Singleton`](#singleton): A simple key.
+    - [`Array`](#array): An array spanning multiple ERC725Y keys.
+    - [`Mapping`](#mapping): A key that maps two words.
+    - [`AddressMapping`](#addressmapping): A key that maps a word to an address.
+    - [`AddressMappingWithGrouping`](#addressmappingwithgrouping): A key that maps a word, to a grouping word to an address.
+    - `valueType`: The type the content MUST be decoded with.
+    - `string`: The bytes are a UTF8 encoded string
+    - `address`: The bytes are an 20 bytes address
+    - `uint256`: The bytes are a uint256
+    - `bytes32`: The bytes are a 32 bytes
+    - `bytes`: The bytes are a bytes
+    - `string[]`: The bytes are a UTF8 encoded string array
+    - `address[]`: The bytes are an 20 bytes address array
+    - `uint256[]`: The bytes are a uint256 array
+    - `bytes[]`: The bytes are a bytes array
+    - `bytesN[]`: The bytes are a N bytes
+    - `valueContent`: The content in the returned value. Valid values are:
+    - `Bytes`: The content are bytes.
+    - `BytesN`: The content are bytes with length N.
+    - `Number`: The content is a number.
+    - `String`: The content is a UTF8 string.
+    - `Address`: The content is an address.
+    - `Keccak256`: The content is an keccak256 32 bytes hash.
+    - [`AssetURL`](#asseturl): The content contains the hash function, hash and link to the asset file.
+    - [`JSONURL`](#jsonurl): The content contains the hash function, hash and link to the JSON file.
+    - `URL`: The content is an URL encoded as UTF8 string.
+    - `Markdown`: The content is structured Markdown mostly encoded as UTF8 string.
+    - `0x1345ABCD...`: If the value content are specific bytes, than the returned value is expected to equal those bytes.
+  
 ### Singleton
 
 A simple key is constructed using `bytes32(keccak256(KeyName))`,
@@ -83,8 +85,8 @@ Below is an example of a Singleton key type:
 An initial key of an array containing the array length constructed using `bytes32(keccak256(KeyName))`.
 Subsequent keys consist of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`.
 
-_The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
-Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit._
+*The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
+Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit.*
 
 If you require multiple keys of the same key type they MUST be defined as follows:
 
@@ -102,7 +104,8 @@ This would looks as follows for `LSP3IssuedAssets[]`:
 - element number: key: `0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0`, value: `0x0000000000000000000000000000000000000000000000000000000000000002` (2 elements)
 - element 1: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000`, value: `0x123...` (element 0)
 - element 2: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001`, value: `0x321...` (element 1)
-  ...
+...
+
 
 Special key types exist for **array elements**:
 
@@ -113,13 +116,13 @@ Below is an example of an Array key type:
 
 ```json
 {
-  "name": "LSP3IssuedAssets[]",
-  "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
-  "keyType": "Array",
-  "valueContent": "Number",
-  "valueType": "uint256",
-  "elementValueContent": "Address",
-  "elementValueType": "address"
+    "name": "LSP3IssuedAssets[]",
+    "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
+    "keyType": "Array",
+    "valueContent": "Number",
+    "valueType": "uint256",
+    "elementValueContent": "Address",
+    "elementValueType": "address"
 }
 ```
 
@@ -142,7 +145,7 @@ value: 0xcafecafecafecafecafecafecafecafecafecafe
 
 ### Mapping
 
-A mapping key is constructed using `bytes16(keccak256(FirstWord)) + bytes12(0) + bytes4(keccak256(LastWord))`,
+A mapping key is constructed using `bytes16(keccak256(FirstWord)) + bytes12(0) + bytes4(keccak256(LastWord))`,    
 
 Below is an example of a mapping key type:
 
@@ -176,7 +179,7 @@ Below is an example of an address mapping key type:
 
 ### AddressMappingWithGrouping
 
-A mapping key, constructed using `bytes4(keccak256(FirstWord)) + bytes4(0) + bytes2(keccak256(SecondWord)) + bytes2(0) + bytes20(address)`,
+A mapping key, constructed using `bytes4(keccak256(FirstWord)) + bytes4(0) + bytes2(keccak256(SecondWord)) + bytes2(0) + bytes20(address)`,     
 
 e.g. `AddressPermissions:Permissions:<address>` > `0x4b80742d 00000000 eced 0000 cafecafecafecafecafecafecafecafecafecafe`.
 
@@ -203,7 +206,7 @@ Known hash functions:
 
 ### JSONURL
 
-The content is bytes containing the following format:  
+The content is bytes containing the following format:     
 `bytes4(keccack256('hashFunction'))` + `bytes32(keccack256(JSON.stringify(JSON)))` + `utf8ToHex('JSONURL')`
 
 Known hash functions:
@@ -236,7 +239,7 @@ let url = web3.utils.utf8ToHex('ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPD
 let JSONURL = hashFunction + hash.substring(2) + url.substring(2)
               ^              ^                   ^
               0x6f357c6a   + 820464ddfac1be... + 696670733a2f2...
-
+              
 // structure of the JSONURL
 0x6f357c6a +       820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361 + 696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178
 ^                  ^                                                                  ^
@@ -275,11 +278,12 @@ if(hashFunction === '0x6f357c6a') {
 }
 ```
 
+
 ## Rationale
 
-The structure of the key value layout as JSON allows interfaces to auto decode these key values as they will know how to decode them.  
-`keyType` always describes _how_ a key MUST be treated.  
-and `valueType` describes how the value MUST be decoded. And `value` always describes _how_ a value SHOULD be treated.
+The structure of the key value layout as JSON allows interfaces to auto decode these key values as they will know how to decode them.   
+`keyType` always describes *how* a key MUST be treated.    
+and `valueType` describes how the value MUST be decoded. And `value` always describes *how* a value SHOULD be treated.
 
 ## Example
 
@@ -287,29 +291,29 @@ To allow interfaces to auto decode an ERC725Y key value store using the ERC725Y 
 
 ```json
 [
-  {
-    "name": "SupportedStandards:ERC725Account",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
-    "keyType": "Mapping",
-    "valueContent": "0xafdeb5d6",
-    "valueType": "bytes"
-  },
-  {
-    "name": "LSP3Profile",
-    "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
-    "keyType": "Singleton",
-    "valueContent": "JSONURL",
-    "valueType": "bytes"
-  },
-  {
-    "name": "LSP3IssuedAssets[]",
-    "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
-    "keyType": "Array",
-    "valueContent": "Number",
-    "valueType": "uint256",
-    "elementValueContent": "Address",
-    "elementValueType": "address"
-  }
+    {
+        "name": "SupportedStandards:ERC725Account",
+        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
+        "keyType": "Mapping",
+        "valueContent": "0xafdeb5d6",
+        "valueType": "bytes"
+    },
+    {
+        "name": "LSP3Profile",
+        "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
+        "keyType": "Singleton",
+        "valueContent": "JSONURL",
+        "valueType": "bytes"
+    },
+    {
+        "name": "LSP3IssuedAssets[]",
+        "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
+        "keyType": "Array",
+        "valueContent": "Number",
+        "valueType": "uint256",
+        "elementValueContent": "Address",
+        "elementValueType": "address"
+    }
 ]
 ```
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -1,7 +1,7 @@
 ---
 lip: 2
 title: ERC725Y JSON Schema
-author: Fabian Vogelsteller <fabian@lukso.network>
+author: Fabian Vogelsteller <fabian@lukso.network> 
 discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
@@ -40,7 +40,7 @@ To make ERC725Y keys readable we define the following key value types:
     - [`Mapping`](#mapping): A key that maps two words.
     - [`AddressMapping`](#addressmapping): A key that maps a word to an address.
     - [`AddressMappingWithGrouping`](#addressmappingwithgrouping): A key that maps a word, to a grouping word to an address.
-    - `valueType`: The type the content MUST be decoded with.
+- `valueType`: The type the content MUST be decoded with.
     - `string`: The bytes are a UTF8 encoded string
     - `address`: The bytes are an 20 bytes address
     - `uint256`: The bytes are a uint256
@@ -51,8 +51,8 @@ To make ERC725Y keys readable we define the following key value types:
     - `uint256[]`: The bytes are a uint256 array
     - `bytes[]`: The bytes are a bytes array
     - `bytesN[]`: The bytes are a N bytes
-    - `valueContent`: The content in the returned value. Valid values are:
-    - `Bytes`: The content are bytes.
+- `valueContent`: The content in the returned value. Valid values are:
+    - `Bytes`: The content are bytes. 
     - `BytesN`: The content are bytes with length N.
     - `Number`: The content is a number.
     - `String`: The content is a UTF8 string.

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -1,14 +1,13 @@
 ---
 lip: 2
 title: ERC725Y JSON Schema
-author: Fabian Vogelsteller <fabian@lukso.network> 
+author: Fabian Vogelsteller <fabian@lukso.network>
 discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2020-07-01
 requires: ERC725Y
 ---
-
 
 ## Simple Summary
 
@@ -21,49 +20,48 @@ This schema allows to standardize the key values that can be used in ERC725Y sub
 
 ## Motivation
 
-This schema defines a way to make those key values automatically parsable, so a interface or smart contract knows how to read and interact with them. 
+This schema defines a way to make those key values automatically parsable, so a interface or smart contract knows how to read and interact with them.
 
 This schema is for example used in [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) based smart contracts like
 [LSP3-UniversalProfile](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md) and [LSP4-DigitalCertificate](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-4-DigitalCertificate.md).
 
-
 ## Specification
 
-To make ERC725Y keys readable we define the following key value types:   
+To make ERC725Y keys readable we define the following key value types:  
 (Note: this set is not complete yet, and should be extended over time)
 
 - `name`: Describes the name of the key, SHOULD compromise of the Standards name + sub type. e.g: `LSP2Name`
 - `key`: the keccak256 hash of the name. This is the actual key that MUST be retrievable via `ERC725Y.getData(bytes32 key)`. e.g: `keccack256('LSP2Name') = 0xf9e26448acc9f20625c059a95279675b8f58ba4f06d262f83a32b4dd35dee019`
 - `keyType`: Types that determine how the values should be interpreted. Valid types are:
-    - [`Singleton`](#singleton): A simple key.
-    - [`Array`](#array): An array spanning multiple ERC725Y keys.
-    - [`Mapping`](#mapping): A key that maps two words.
-    - [`AddressMapping`](#addressmapping): A key that maps a word to an address.
-    - [`AddressMappingWithGrouping`](#addressmappingwithgrouping): A key that maps a word, to a grouping word to an address.
-- `valueType`: The type the content MUST be decoded with.
-    - `string`: The bytes are a UTF8 encoded string
-    - `address`: The bytes are an 20 bytes address
-    - `uint256`: The bytes are a uint256
-    - `bytes32`: The bytes are a 32 bytes
-    - `bytes`: The bytes are a bytes
-    - `string[]`: The bytes are a UTF8 encoded string array
-    - `address[]`: The bytes are an 20 bytes address array
-    - `uint256[]`: The bytes are a uint256 array
-    - `bytes[]`: The bytes are a bytes array
-    - `bytesN[]`: The bytes are a N bytes
-- `valueContent`: The content in the returned value. Valid values are:
-    - `Bytes`: The content are bytes. 
-    - `BytesN`: The content are bytes with length N.
-    - `Number`: The content is a number.
-    - `String`: The content is a UTF8 string.
-    - `Address`: The content is an address.
-    - `Keccak256`: The content is an keccak256 32 bytes hash.
-    - [`AssetURL`](#asseturl): The content contains the hash function, hash and link to the asset file.
-    - [`JSONURL`](#jsonurl): The content contains the hash function, hash and link to the JSON file.
-    - `URL`: The content is an URL encoded as UTF8 string.
-    - `Markdown`: The content is structured Markdown mostly encoded as UTF8 string.
-    - `0x1345ABCD...`: If the value content are specific bytes, than the returned value is expected to equal those bytes.
-  
+  - [`Singleton`](#singleton): A simple key.
+  - [`Array`](#array): An array spanning multiple ERC725Y keys.
+  - [`Mapping`](#mapping): A key that maps two words.
+  - [`AddressMapping`](#addressmapping): A key that maps a word to an address.
+  - [`AddressMappingWithGrouping`](#addressmappingwithgrouping): A key that maps a word, to a grouping word to an address.
+  - `valueType`: The type the content MUST be decoded with.
+  - `string`: The bytes are a UTF8 encoded string
+  - `address`: The bytes are an 20 bytes address
+  - `uint256`: The bytes are a uint256
+  - `bytes32`: The bytes are a 32 bytes
+  - `bytes`: The bytes are a bytes
+  - `string[]`: The bytes are a UTF8 encoded string array
+  - `address[]`: The bytes are an 20 bytes address array
+  - `uint256[]`: The bytes are a uint256 array
+  - `bytes[]`: The bytes are a bytes array
+  - `bytesN[]`: The bytes are a N bytes
+  - `valueContent`: The content in the returned value. Valid values are:
+  - `Bytes`: The content are bytes.
+  - `BytesN`: The content are bytes with length N.
+  - `Number`: The content is a number.
+  - `String`: The content is a UTF8 string.
+  - `Address`: The content is an address.
+  - `Keccak256`: The content is an keccak256 32 bytes hash.
+  - [`AssetURL`](#asseturl): The content contains the hash function, hash and link to the asset file.
+  - [`JSONURL`](#jsonurl): The content contains the hash function, hash and link to the JSON file.
+  - `URL`: The content is an URL encoded as UTF8 string.
+  - `Markdown`: The content is structured Markdown mostly encoded as UTF8 string.
+  - `0x1345ABCD...`: If the value content are specific bytes, than the returned value is expected to equal those bytes.
+
 ### Singleton
 
 A simple key is constructed using `bytes32(keccak256(KeyName))`,
@@ -85,8 +83,8 @@ Below is an example of a Singleton key type:
 An initial key of an array containing the array length constructed using `bytes32(keccak256(KeyName))`.
 Subsequent keys consist of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`.
 
-*The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
-Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit.*
+_The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
+Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit._
 
 If you require multiple keys of the same key type they MUST be defined as follows:
 
@@ -99,13 +97,12 @@ For all other elements:
 - The second 16 bytes is a `uint128` of the number of the element
 - Elements start at number `0`
 
-This would looks as follows for `LSP2IssuedAssets[]`:
+This would looks as follows for `LSP3IssuedAssets[]`:
 
-- element number: key: `0xb8c4a0b76ed8454e098b20a987a980e69abe3b1a88567ae5472af5f863f8c8f9`, value: `0x0000000000000000000000000000000000000000000000000000000000000002` (2 elements)
-- element 1: key: `0xb8c4a0b76ed8454e098b20a987a980e600000000000000000000000000000000`, value: `0x123...` (element 0)
-- element 2: key: `0xb8c4a0b76ed8454e098b20a987a980e600000000000000000000000000000001`, value: `0x321...` (element 1)
-...
-
+- element number: key: `0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0`, value: `0x0000000000000000000000000000000000000000000000000000000000000002` (2 elements)
+- element 1: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000`, value: `0x123...` (element 0)
+- element 2: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001`, value: `0x321...` (element 1)
+  ...
 
 Special key types exist for **array elements**:
 
@@ -116,36 +113,36 @@ Below is an example of an Array key type:
 
 ```json
 {
-    "name": "LSP2IssuedAssets[]",
-    "key": "0xb8c4a0b76ed8454e098b20a987a980e69abe3b1a88567ae5472af5f863f8c8f9",
-    "keyType": "Array",
-    "valueContent": "Number",
-    "valueType": "uint256",
-    "elementValueContent": "Address",
-    "elementValueType": "address"
+  "name": "LSP3IssuedAssets[]",
+  "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
+  "keyType": "Array",
+  "valueContent": "Number",
+  "valueType": "uint256",
+  "elementValueContent": "Address",
+  "elementValueType": "address"
 }
 ```
 
 #### Example
 
 ```solidity
-key: keccak256('LSP2IssuedAssets[]') = 0xb8c4a0b76ed8454e098b20a987a980e69abe3b1a88567ae5472af5f863f8c8f9
+key: keccak256('LSP3IssuedAssets[]') = 0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0
 value: uint256 (array length) e.g. 0x0000000000000000000000000000000000000000000000000000000000000002
 
 // array items
 
 // element 0
-key: 0xb8c4a0b76ed8454e098b20a987a980e600000000000000000000000000000000
+key: 0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000
 value: 0xcafecafecafecafecafecafecafecafecafecafe
 
 // element 1
-key: 0xb8c4a0b76ed8454e098b20a987a980e600000000000000000000000000000001
+key: 0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001
 value: 0xcafecafecafecafecafecafecafecafecafecafe
 ```
 
 ### Mapping
 
-A mapping key is constructed using `bytes16(keccak256(FirstWord)) + bytes12(0) + bytes4(keccak256(LastWord))`,    
+A mapping key is constructed using `bytes16(keccak256(FirstWord)) + bytes12(0) + bytes4(keccak256(LastWord))`,
 
 Below is an example of a mapping key type:
 
@@ -179,7 +176,7 @@ Below is an example of an address mapping key type:
 
 ### AddressMappingWithGrouping
 
-A mapping key, constructed using `bytes4(keccak256(FirstWord)) + bytes4(0) + bytes2(keccak256(SecondWord)) + bytes2(0) + bytes20(address)`,     
+A mapping key, constructed using `bytes4(keccak256(FirstWord)) + bytes4(0) + bytes2(keccak256(SecondWord)) + bytes2(0) + bytes20(address)`,
 
 e.g. `AddressPermissions:Permissions:<address>` > `0x4b80742d 00000000 eced 0000 cafecafecafecafecafecafecafecafecafecafe`.
 
@@ -206,7 +203,7 @@ Known hash functions:
 
 ### JSONURL
 
-The content is bytes containing the following format:     
+The content is bytes containing the following format:  
 `bytes4(keccack256('hashFunction'))` + `bytes32(keccack256(JSON.stringify(JSON)))` + `utf8ToHex('JSONURL')`
 
 Known hash functions:
@@ -239,7 +236,7 @@ let url = web3.utils.utf8ToHex('ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPD
 let JSONURL = hashFunction + hash.substring(2) + url.substring(2)
               ^              ^                   ^
               0x6f357c6a   + 820464ddfac1be... + 696670733a2f2...
-              
+
 // structure of the JSONURL
 0x6f357c6a +       820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361 + 696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178
 ^                  ^                                                                  ^
@@ -278,12 +275,11 @@ if(hashFunction === '0x6f357c6a') {
 }
 ```
 
-
 ## Rationale
 
-The structure of the key value layout as JSON allows interfaces to auto decode these key values as they will know how to decode them.   
-`keyType` always describes *how* a key MUST be treated.    
-and `valueType` describes how the value MUST be decoded. And `value` always describes *how* a value SHOULD be treated.
+The structure of the key value layout as JSON allows interfaces to auto decode these key values as they will know how to decode them.  
+`keyType` always describes _how_ a key MUST be treated.  
+and `valueType` describes how the value MUST be decoded. And `value` always describes _how_ a value SHOULD be treated.
 
 ## Example
 
@@ -291,29 +287,29 @@ To allow interfaces to auto decode an ERC725Y key value store using the ERC725Y 
 
 ```json
 [
-    {
-        "name": "SupportedStandards:ERC725Account",
-        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
-        "keyType": "Mapping",
-        "valueContent": "0xafdeb5d6",
-        "valueType": "bytes"
-    },
-    {
-        "name": "LSP3Profile",
-        "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
-        "keyType": "Singleton",
-        "valueContent": "JSONURL",
-        "valueType": "bytes"
-    },
-    {
-        "name": "LSP2IssuedAssets[]",
-        "key": "0xb8c4a0b76ed8454e098b20a987a980e69abe3b1a88567ae5472af5f863f8c8f9",
-        "keyType": "Array",
-        "valueContent": "Number",
-        "valueType": "uint256",
-        "elementValueContent": "Address",
-        "elementValueType": "address"
-    }
+  {
+    "name": "SupportedStandards:ERC725Account",
+    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
+    "keyType": "Mapping",
+    "valueContent": "0xafdeb5d6",
+    "valueType": "bytes"
+  },
+  {
+    "name": "LSP3Profile",
+    "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
+    "keyType": "Singleton",
+    "valueContent": "JSONURL",
+    "valueType": "bytes"
+  },
+  {
+    "name": "LSP3IssuedAssets[]",
+    "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
+    "keyType": "Array",
+    "valueContent": "Number",
+    "valueType": "uint256",
+    "elementValueContent": "Address",
+    "elementValueType": "address"
+  }
 ]
 ```
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -9,14 +9,15 @@ created: 2021-08-03
 requires: LSP2, ERC165, ERC725Y, ERC1271
 ---
 
-
 ## Simple Summary
+
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the LIP.-->
 
 This standard describes a `KeyManager` contract with a set of pre-defined permissions that can be used as a controller for a ERC725 account.
 Such permissions are useful to control actions performed by other addresses when interacting with an [ERC725Account](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md).
 
 ## Abstract
+
 <!--A short (~200 word) description of the technical issue being addressed.-->
 
 This standard allows for a controller and permissioning layer to be set on an ERC725 account.
@@ -27,31 +28,28 @@ Such actions are represented as permissions that can be assigned to any third pa
 
 ![lsp6-key-manager-flow-chart](https://user-images.githubusercontent.com/31145285/129574099-9eba52d4-4f82-4f11-8ac5-8bfa18ce97d6.jpeg)
 
-
-
-
 ## Motivation
-<!--The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.--> 
+
+<!--The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
 
 ERC725 accounts enable to own a universal profile, that:
-* can hold multiple assets (tokens, NFTs...).
-* many addresses (whether users or contracts) can interact with.
 
-However, data stored in a ERC725 account (under the JSON schema) can be easily updated by any address, using the function `setData(...)`. 
+- can hold multiple assets (tokens, NFTs...).
+- many addresses (whether users or contracts) can interact with.
+
+However, data stored in a ERC725 account (under the JSON schema) can be easily updated by any address, using the function `setData(...)`.
 Currently, ERC725 accounts do not implement any form of delegate access control, so to grant or restrict third parties to perform action on their behalf.
 
 What is required is a contract design that enable ERC725 account owners to:
 
-* control who can interact with their profile.
-* grant permissions, so to allow third parties to act on their behalf. 
-
+- control who can interact with their profile.
+- grant permissions, so to allow third parties to act on their behalf.
 
 ## Specification
 
-
 ### Permission Keys on the ERC725Account
 
-The following keys can be used to get and set permissions of certain addresses on a ERC725 account.   
+The following keys can be used to get and set permissions of certain addresses on a ERC725 account.  
 These keys are based on the [LSP2-ERC725YJSONSchema](https://github.com/CJ42/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[AddressMappingWithGrouping](https://github.com/CJ42/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#addressmappingwithgrouping)**
 
 The KeyManager will read the permissions from the ERC725Account key value store, to determine if a key is allowed to perform certain actions.
@@ -62,25 +60,25 @@ Holds the permissions for a key. See [Permission Values](#permission-values-in-a
 
 ```json
 {
-    "name": "AddressPermissions:Permissions:<address>",
-    "key": "0x4b80742d0000000082ac0000<address>",
-    "keyType": "Singleton",
-    "valueContent": "BitArray",
-    "valueType": "bytes4"
+  "name": "AddressPermissions:Permissions:<address>",
+  "key": "0x4b80742d0000000082ac0000<address>",
+  "keyType": "Singleton",
+  "valueContent": "BitArray",
+  "valueType": "bytes4"
 }
 ```
-    
+
 #### AddressPermissions:AllowedAddresses:\<address\>
 
 Holds an array of address, the key is allowed to talk to.
 
 ```json
 {
-    "name": "AddressPermissions:AllowedAddresses:<address>",
-    "key": "0x4b80742d00000000c6dd0000<address>",
-    "keyType": "Singleton",
-    "valueContent": "Address",
-    "valueType": "address[]"
+  "name": "AddressPermissions:AllowedAddresses:<address>",
+  "key": "0x4b80742d00000000c6dd0000<address>",
+  "keyType": "Singleton",
+  "valueContent": "Address",
+  "valueType": "address[]"
 }
 ```
 
@@ -90,11 +88,11 @@ Holds an array of bytes4 function signatures, the key is allowed to call on othe
 
 ```json
 {
-    "name": "AddressPermissions:AllowedFunctions:<address>",
-    "key": "0x4b80742d000000008efe0000<address>",
-    "keyType": "Singleton",
-    "valueContent": "Bytes4",
-    "valueType": "bytes4[]"
+  "name": "AddressPermissions:AllowedFunctions:<address>",
+  "key": "0x4b80742d000000008efe0000<address>",
+  "keyType": "Singleton",
+  "valueContent": "Bytes4",
+  "valueType": "bytes4[]"
 }
 ```
 
@@ -104,11 +102,11 @@ Holds an array of bytes4 ERC165 standards signatures, other smart contracts shou
 
 ```json
 {
-    "name": "AddressPermissions:AllowedStandards:<address>",
-    "key": "0x4b80742d000000003efa0000<address>",
-    "keyType": "Singleton",
-    "valueContent": "Bytes4",
-    "valueType": "bytes4[]"
+  "name": "AddressPermissions:AllowedStandards:<address>",
+  "key": "0x4b80742d000000003efa0000<address>",
+  "keyType": "Singleton",
+  "valueContent": "Bytes4",
+  "valueType": "bytes4[]"
 }
 ```
 
@@ -127,14 +125,9 @@ TRANSFERVALUE = 0x40;   // 0100 0000
 SIGN          = 0x80;   // 1000 0000
 ```
 
-
 ![lsp6-key-manager-permissions-range](https://user-images.githubusercontent.com/31145285/129574070-8aceb32c-edf1-4134-b7c8-ca242a14c9c3.jpeg)
 
-
-
 ### Methods
-
-
 
 #### execute
 
@@ -149,9 +142,6 @@ Execute a calldata payload on an ERC725 account.
 - `_data`: The call data to be executed. The first 4 bytes of the `_data` payload MUST correspond to one of the function selector in the ERC725 account, such as `setData(...)`, `execute(...)` or `transferOwnership(...)`.
 
 **returns:** `bool` , `true` if the call on ERC725 account succeeded, `false` otherwise.
-
-
-
 
 #### getNonce
 
@@ -168,11 +158,9 @@ Read [what are multi-channel nonces](#what-are-multi-channel-nonces)
 **Parameters:**
 
 - `_address`: the address of the signer of the transaction.
-- `_channel` :  the channel which the signer wants to use for executing the transaction.
+- `_channel` : the channel which the signer wants to use for executing the transaction.
 
 **returns:** `uint256` , returns the current nonce.
-
-
 
 #### executeRelayCall
 
@@ -195,7 +183,6 @@ Allows anybody to execute `_data` payload on a ERC725 account, given they have a
 
 <br>
 
-
 ### What are multi-channel nonces
 
 This concept was taken from <https://github.com/amxx/permit#out-of-order-execution>.
@@ -210,7 +197,7 @@ However, **sequential nonces come with the following limitation**:
 
 Some users may want to sign multiple message, allowing the transfer of different assets to different recipients. In that case, the recipient want to be able to use / transfer their assets whenever they want, and will certainly not want to wait on anyone before signing another transaction.
 
- This is where **out-of-order execution** comes in.
+This is where **out-of-order execution** comes in.
 
 #### Introducing multi-channel nonces
 
@@ -222,22 +209,21 @@ The benefit is that the signer key can determine for which channel to sign the n
 
 The Key Manager allows out-of-order execution of messages by using nonces through multiple channels.
 
- Nonces are represented as `uint256` from the concatenation of two `uint128` : the `channelId` and the `nonceId`.
+Nonces are represented as `uint256` from the concatenation of two `uint128` : the `channelId` and the `nonceId`.
 
- - left most 128 bits : `channelId`
- - right most 128 bits: `nonceId`
+- left most 128 bits : `channelId`
+- right most 128 bits: `nonceId`
 
 ![multi-channel-nonce](https://user-images.githubusercontent.com/86341666/132648960-297b1803-0c36-413d-be44-6fa7ea709c13.jpeg)
 
-
 <p align="center"><i> Example of multi channel nonce, where channelId = 5 and nonceId = 1 </i></p>
-
 
 The current nonce can be queried using:
 
 ```solidity
 function getNonce(address _address, uint256 _channel) public view returns (uint256)
-````
+```
+
 Since the `channelId` represents the left-most 128 bits, using a minimal value like 1 will return a huge `nonce` number: `2**128` equal to 3402823669209384634633746074317682114**56**.
 
 After the signed transaction is executed the `nonceId` will be incremented by 1, this will increment the `nonce` by 1 as well because the nonceId represents the first 128 bits of the nonce so it will be 3402823669209384634633746074317682114**57**.
@@ -247,24 +233,26 @@ After the signed transaction is executed the `nonceId` will be incremented by 1,
 _nonces[signer][nonce >> 128]++
 
 ```
+
 `nonce >> 128` represents the channel which the signer chose for executing the transaction. After looking up the nonce of the signer at that specific channel it will be incremented by 1 `++`.<br>
 
 For sequential messages, users could use channel `0` and for out-of-order messages they could use channel `n`.
 
 **Important:** It's up to the user to choose the channel that he wants to sign multiple sequential orders on it, not necessary `0`.
 
-
 ## Rationale
+
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
 This standard was inspired by how files permissions are designed in UNIX based file systems.
 
 Files are assigned permissions as a 3 digit numbers, where each of the 3 digits is an octal value representing a set of permissions.
-The octal value is calculated as the sum of permissions, where *read* = **4**, *write* = **2**, and *execute* = **1**
+The octal value is calculated as the sum of permissions, where _read_ = **4**, _write_ = **2**, and _execute_ = **1**
 
-To illustrate, for a file set with permission `755`, the group permission (second digit) would be *read* and *execute* (See figure below). Each number is simply a **three binary placeholder, each one holding the number that correspond to the access level in r, w, x order**.
-
+To illustrate, for a file set with permission `755`, the group permission (second digit) would be _read_ and _execute_ (See figure below). Each number is simply a **three binary placeholder, each one holding the number that correspond to the access level in r, w, x order**.
 
 ## Implementation
+
 <!--The implementations must be completed before any LIP is given status "Final", but it need not be completed before the LIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
 
 A implementation can be found in the [lukso-network/universalprofile-smart-contracts](https://github.com/lukso-network/universalprofile-smart-contracts/blob/main/contracts/LSP3Account.sol);
@@ -274,34 +262,34 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
 
 ```json
 [
-    {
-        "name": "AddressPermissions:Permissions:<address>",
-        "key": "0x4b80742d0000000082ac0000<address>",
-        "keyType": "Singleton",
-        "valueContent": "BitArray",
-        "valueType": "bytes4"
-    },
-    {
-        "name": "AddressPermissions:AllowedAddresses:<address>",
-        "key": "0x4b80742d00000000c6dd0000<address>",
-        "keyType": "Singleton",
-        "valueContent": "Address",
-        "valueType": "address[]"
-    },
-    {
-        "name": "AddressPermissions:AllowedFunctions:<address>",
-        "key": "0x4b80742d000000008efe0000<address>",
-        "keyType": "Singleton",
-        "valueContent": "Bytes4",
-        "valueType": "bytes4[]"
-    },
-    {
-        "name": "AddressPermissions:AllowedStandards:<address>",
-        "key": "0x4b80742d000000003efa0000<address>",
-        "keyType": "Singleton",
-        "valueContent": "Bytes4",
-        "valueType": "bytes4[]"
-    }
+  {
+    "name": "AddressPermissions:Permissions:<address>",
+    "key": "0x4b80742d0000000082ac0000<address>",
+    "keyType": "Singleton",
+    "valueContent": "BitArray",
+    "valueType": "bytes4"
+  },
+  {
+    "name": "AddressPermissions:AllowedAddresses:<address>",
+    "key": "0x4b80742d00000000c6dd0000<address>",
+    "keyType": "Singleton",
+    "valueContent": "Address",
+    "valueType": "address[]"
+  },
+  {
+    "name": "AddressPermissions:AllowedFunctions:<address>",
+    "key": "0x4b80742d000000008efe0000<address>",
+    "keyType": "Singleton",
+    "valueContent": "Bytes4",
+    "valueType": "bytes4[]"
+  },
+  {
+    "name": "AddressPermissions:AllowedStandards:<address>",
+    "key": "0x4b80742d000000003efa0000<address>",
+    "keyType": "Singleton",
+    "valueContent": "Bytes4",
+    "valueType": "bytes4[]"
+  }
 ]
 ```
 
@@ -310,21 +298,21 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
 ```solidity
 
 interface ILSP6  /* is ERC165 */ {
-        
-    event Executed(uint256 indexed  _value, bytes _data); 
-    
-    
+
+    event Executed(uint256 indexed  _value, bytes _data);
+
+
     function getNonce(address _address) external view returns (uint256);
-    
+
     function execute(bytes calldata _data) external payable returns (bool);
-    
+
     function executeRelayCall(bytes calldata _data, address _signedFor, uint256 _nonce, bytes memory _signature) external payable returns (bool);
- 
-        
+
+
     // ERC1271
-    
+
     function isValidSignature(bytes32 _hash, bytes memory _signature) external view returns (bytes4 magicValue);
-    
+
 }
 
 ```

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -220,11 +220,9 @@ Nonces are represented as `uint256` from the concatenation of two `uint128` : th
 - left most 128 bits : `channelId`
 - right most 128 bits: `nonceId`
 
-![multi-channel-nonce](https://user-images.githubusercontent.com/31145285/133279354-82bebc4f-21f4-40e4-b959-93ccd624e5c4.jpg)
+![multi-channel-nonce](https://user-images.githubusercontent.com/86341666/132648960-297b1803-0c36-413d-be44-6fa7ea709c13.jpeg)
 
-<p align="center">
-  <i> Example of multi channel nonce, where channelId = 5 and nonceId = 1 </i>
-</p>
+<p align="center"><i> Example of multi channel nonce, where channelId = 5 and nonceId = 1 </i></p>
 
 The current nonce can be queried using:
 
@@ -273,28 +271,28 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
   {
     "name": "AddressPermissions:Permissions:<address>",
     "key": "0x4b80742d0000000082ac0000<address>",
-    "keyType": "AddressMappingWithGrouping",
+    "keyType": "Singleton",
     "valueContent": "BitArray",
     "valueType": "bytes4"
   },
   {
     "name": "AddressPermissions:AllowedAddresses:<address>",
     "key": "0x4b80742d00000000c6dd0000<address>",
-    "keyType": "AddressMappingWithGrouping",
+    "keyType": "Singleton",
     "valueContent": "Address",
     "valueType": "address[]"
   },
   {
     "name": "AddressPermissions:AllowedFunctions:<address>",
     "key": "0x4b80742d000000008efe0000<address>",
-    "keyType": "AddressMappingWithGrouping",
+    "keyType": "Singleton",
     "valueContent": "Bytes4",
     "valueType": "bytes4[]"
   },
   {
     "name": "AddressPermissions:AllowedStandards:<address>",
     "key": "0x4b80742d000000003efa0000<address>",
-    "keyType": "AddressMappingWithGrouping",
+    "keyType": "Singleton",
     "valueContent": "Bytes4",
     "valueType": "bytes4[]"
   }

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -180,6 +180,12 @@ Allows anybody to execute `_data` payload on a ERC725 account, given they have a
 **returns:** `bool` , true if the call on ERC725 account succeeded, false otherwise.
 
 **Important:** the message to sign MUST be of the following format: `<KeyManager address>` + `<signer nonce>` + `<_data payload>` .
+These 3 parameters MUST be:
+
+- packed encoded (not zero padded, leading `0`s are removed)
+- hashed with `keccak256`
+
+The final message MUST be signed using ethereum specific signature, based on [EIP712](https://eips.ethereum.org/EIPS/eip-712).
 
 <br>
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -62,7 +62,7 @@ Holds the permissions for a key. See [Permission Values](#permission-values-in-a
 {
   "name": "AddressPermissions:Permissions:<address>",
   "key": "0x4b80742d0000000082ac0000<address>",
-  "keyType": "Singleton",
+  "keyType": "AddressMappingWithGrouping",
   "valueContent": "BitArray",
   "valueType": "bytes4"
 }
@@ -76,7 +76,7 @@ Holds an array of address, the key is allowed to talk to.
 {
   "name": "AddressPermissions:AllowedAddresses:<address>",
   "key": "0x4b80742d00000000c6dd0000<address>",
-  "keyType": "Singleton",
+  "keyType": "AddressMappingWithGrouping",
   "valueContent": "Address",
   "valueType": "address[]"
 }
@@ -90,7 +90,7 @@ Holds an array of bytes4 function signatures, the key is allowed to call on othe
 {
   "name": "AddressPermissions:AllowedFunctions:<address>",
   "key": "0x4b80742d000000008efe0000<address>",
-  "keyType": "Singleton",
+  "keyType": "AddressMappingWithGrouping",
   "valueContent": "Bytes4",
   "valueType": "bytes4[]"
 }
@@ -104,7 +104,7 @@ Holds an array of bytes4 ERC165 standards signatures, other smart contracts shou
 {
   "name": "AddressPermissions:AllowedStandards:<address>",
   "key": "0x4b80742d000000003efa0000<address>",
-  "keyType": "Singleton",
+  "keyType": "AddressMappingWithGrouping",
   "valueContent": "Bytes4",
   "valueType": "bytes4[]"
 }

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -248,7 +248,8 @@ The Key Manager allows out-of-order execution of messages by using nonces throug
  - left most 128 bits : `channelId`
  - right most 128 bits: `nonceId`
 
-![multi-channel-nonce](https://user-images.githubusercontent.com/86341666/31145285/133279354-82bebc4f-21f4-40e4-b959-93ccd624e5c4.jpg)
+
+![multi-channel-nonce](https://user-images.githubusercontent.com/31145285/133292580-42817340-104e-48c5-832b-533842b98d26.jpg)
 
 <p align="center"><i> Example of multi channel nonce, where channelId = 5 and nonceId = 1 </i></p>
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -57,6 +57,20 @@ These keys are based on the [LSP2-ERC725YJSONSchema](https://github.com/CJ42/LIP
 
 The KeyManager will read the permissions from the ERC725Account key value store, to determine if a key is allowed to perform certain actions.
 
+#### AddressPermissions[]
+
+Holds an array of address, that have permission some permission sets to interact with the ERC725Account.
+
+```json
+{
+    "name": "AddressPermissions[]",
+    "key": "0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3",
+    "keyType": "Array",
+    "valueContent": "Address",
+    "valueType": "address"
+}
+```
+
 #### AddressPermissions:Permissions:\<address\>
 
 Holds the permissions for a key. See [Permission Values](#permission-values-in-addresspermissionspermissionsaddress) for details.

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -271,28 +271,28 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
   {
     "name": "AddressPermissions:Permissions:<address>",
     "key": "0x4b80742d0000000082ac0000<address>",
-    "keyType": "Singleton",
+    "keyType": "AddressMappingWithGrouping",
     "valueContent": "BitArray",
     "valueType": "bytes4"
   },
   {
     "name": "AddressPermissions:AllowedAddresses:<address>",
     "key": "0x4b80742d00000000c6dd0000<address>",
-    "keyType": "Singleton",
+    "keyType": "AddressMappingWithGrouping",
     "valueContent": "Address",
     "valueType": "address[]"
   },
   {
     "name": "AddressPermissions:AllowedFunctions:<address>",
     "key": "0x4b80742d000000008efe0000<address>",
-    "keyType": "Singleton",
+    "keyType": "AddressMappingWithGrouping",
     "valueContent": "Bytes4",
     "valueType": "bytes4[]"
   },
   {
     "name": "AddressPermissions:AllowedStandards:<address>",
     "key": "0x4b80742d000000003efa0000<address>",
-    "keyType": "Singleton",
+    "keyType": "AddressMappingWithGrouping",
     "valueContent": "Bytes4",
     "valueType": "bytes4[]"
   }

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -9,8 +9,8 @@ created: 2021-08-03
 requires: LSP2, ERC165, ERC725Y, ERC1271
 ---
 
-## Simple Summary
 
+## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the LIP.-->
 
 This standard describes a `KeyManager` contract with a set of pre-defined permissions that can be used as a controller for a ERC725 account.
@@ -28,28 +28,31 @@ Such actions are represented as permissions that can be assigned to any third pa
 
 ![lsp6-key-manager-flow-chart](https://user-images.githubusercontent.com/31145285/129574099-9eba52d4-4f82-4f11-8ac5-8bfa18ce97d6.jpeg)
 
-## Motivation
 
+
+
+## Motivation
 <!--The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
 
 ERC725 accounts enable to own a universal profile, that:
+* can hold multiple assets (tokens, NFTs...).
+* many addresses (whether users or contracts) can interact with.
 
-- can hold multiple assets (tokens, NFTs...).
-- many addresses (whether users or contracts) can interact with.
-
-However, data stored in a ERC725 account (under the JSON schema) can be easily updated by any address, using the function `setData(...)`.
+However, data stored in a ERC725 account (under the JSON schema) can be easily updated by any address, using the function `setData(...)`. 
 Currently, ERC725 accounts do not implement any form of delegate access control, so to grant or restrict third parties to perform action on their behalf.
 
 What is required is a contract design that enable ERC725 account owners to:
 
-- control who can interact with their profile.
-- grant permissions, so to allow third parties to act on their behalf.
+* control who can interact with their profile.
+* grant permissions, so to allow third parties to act on their behalf. 
+
 
 ## Specification
 
+
 ### Permission Keys on the ERC725Account
 
-The following keys can be used to get and set permissions of certain addresses on a ERC725 account.  
+The following keys can be used to get and set permissions of certain addresses on a ERC725 account.   
 These keys are based on the [LSP2-ERC725YJSONSchema](https://github.com/CJ42/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[AddressMappingWithGrouping](https://github.com/CJ42/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#addressmappingwithgrouping)**
 
 The KeyManager will read the permissions from the ERC725Account key value store, to determine if a key is allowed to perform certain actions.
@@ -60,25 +63,25 @@ Holds the permissions for a key. See [Permission Values](#permission-values-in-a
 
 ```json
 {
-  "name": "AddressPermissions:Permissions:<address>",
-  "key": "0x4b80742d0000000082ac0000<address>",
-  "keyType": "AddressMappingWithGrouping",
-  "valueContent": "BitArray",
-  "valueType": "bytes4"
+    "name": "AddressPermissions:Permissions:<address>",
+    "key": "0x4b80742d0000000082ac0000<address>",
+    "keyType": "AddressMappingWithGrouping",
+    "valueContent": "BitArray",
+    "valueType": "bytes4"
 }
 ```
-
+    
 #### AddressPermissions:AllowedAddresses:\<address\>
 
 Holds an array of address, the key is allowed to talk to.
 
 ```json
 {
-  "name": "AddressPermissions:AllowedAddresses:<address>",
-  "key": "0x4b80742d00000000c6dd0000<address>",
-  "keyType": "AddressMappingWithGrouping",
-  "valueContent": "Address",
-  "valueType": "address[]"
+    "name": "AddressPermissions:AllowedAddresses:<address>",
+    "key": "0x4b80742d00000000c6dd0000<address>",
+    "keyType": "AddressMappingWithGrouping",
+    "valueContent": "Address",
+    "valueType": "address[]"
 }
 ```
 
@@ -88,11 +91,11 @@ Holds an array of bytes4 function signatures, the key is allowed to call on othe
 
 ```json
 {
-  "name": "AddressPermissions:AllowedFunctions:<address>",
-  "key": "0x4b80742d000000008efe0000<address>",
-  "keyType": "AddressMappingWithGrouping",
-  "valueContent": "Bytes4",
-  "valueType": "bytes4[]"
+    "name": "AddressPermissions:AllowedFunctions:<address>",
+    "key": "0x4b80742d000000008efe0000<address>",
+    "keyType": "AddressMappingWithGrouping",
+    "valueContent": "Bytes4",
+    "valueType": "bytes4[]"
 }
 ```
 
@@ -102,11 +105,11 @@ Holds an array of bytes4 ERC165 standards signatures, other smart contracts shou
 
 ```json
 {
-  "name": "AddressPermissions:AllowedStandards:<address>",
-  "key": "0x4b80742d000000003efa0000<address>",
-  "keyType": "AddressMappingWithGrouping",
-  "valueContent": "Bytes4",
-  "valueType": "bytes4[]"
+    "name": "AddressPermissions:AllowedStandards:<address>",
+    "key": "0x4b80742d000000003efa0000<address>",
+    "keyType": "AddressMappingWithGrouping",
+    "valueContent": "Bytes4",
+    "valueType": "bytes4[]"
 }
 ```
 
@@ -125,9 +128,14 @@ TRANSFERVALUE = 0x40;   // 0100 0000
 SIGN          = 0x80;   // 1000 0000
 ```
 
+
 ![lsp6-key-manager-permissions-range](https://user-images.githubusercontent.com/31145285/129574070-8aceb32c-edf1-4134-b7c8-ca242a14c9c3.jpeg)
 
+
+
 ### Methods
+
+
 
 #### execute
 
@@ -142,6 +150,9 @@ Execute a calldata payload on an ERC725 account.
 - `_data`: The call data to be executed. The first 4 bytes of the `_data` payload MUST correspond to one of the function selector in the ERC725 account, such as `setData(...)`, `execute(...)` or `transferOwnership(...)`.
 
 **returns:** `bool` , `true` if the call on ERC725 account succeeded, `false` otherwise.
+
+
+
 
 #### getNonce
 
@@ -158,9 +169,11 @@ Read [what are multi-channel nonces](#what-are-multi-channel-nonces)
 **Parameters:**
 
 - `_address`: the address of the signer of the transaction.
-- `_channel` : the channel which the signer wants to use for executing the transaction.
+- `_channel` :  the channel which the signer wants to use for executing the transaction.
 
 **returns:** `uint256` , returns the current nonce.
+
+
 
 #### executeRelayCall
 
@@ -189,6 +202,7 @@ The final message MUST be signed using ethereum specific signature, based on [EI
 
 <br>
 
+
 ### What are multi-channel nonces
 
 This concept was taken from <https://github.com/amxx/permit#out-of-order-execution>.
@@ -203,7 +217,7 @@ However, **sequential nonces come with the following limitation**:
 
 Some users may want to sign multiple message, allowing the transfer of different assets to different recipients. In that case, the recipient want to be able to use / transfer their assets whenever they want, and will certainly not want to wait on anyone before signing another transaction.
 
-This is where **out-of-order execution** comes in.
+ This is where **out-of-order execution** comes in.
 
 #### Introducing multi-channel nonces
 
@@ -215,21 +229,21 @@ The benefit is that the signer key can determine for which channel to sign the n
 
 The Key Manager allows out-of-order execution of messages by using nonces through multiple channels.
 
-Nonces are represented as `uint256` from the concatenation of two `uint128` : the `channelId` and the `nonceId`.
+ Nonces are represented as `uint256` from the concatenation of two `uint128` : the `channelId` and the `nonceId`.
 
-- left most 128 bits : `channelId`
-- right most 128 bits: `nonceId`
+ - left most 128 bits : `channelId`
+ - right most 128 bits: `nonceId`
 
 ![multi-channel-nonce](https://user-images.githubusercontent.com/86341666/31145285/133279354-82bebc4f-21f4-40e4-b959-93ccd624e5c4.jpg)
 
 <p align="center"><i> Example of multi channel nonce, where channelId = 5 and nonceId = 1 </i></p>
+
 
 The current nonce can be queried using:
 
 ```solidity
 function getNonce(address _address, uint256 _channel) public view returns (uint256)
 ```
-
 Since the `channelId` represents the left-most 128 bits, using a minimal value like 1 will return a huge `nonce` number: `2**128` equal to 3402823669209384634633746074317682114**56**.
 
 After the signed transaction is executed the `nonceId` will be incremented by 1, this will increment the `nonce` by 1 as well because the nonceId represents the first 128 bits of the nonce so it will be 3402823669209384634633746074317682114**57**.
@@ -239,26 +253,24 @@ After the signed transaction is executed the `nonceId` will be incremented by 1,
 _nonces[signer][nonce >> 128]++
 
 ```
-
 `nonce >> 128` represents the channel which the signer chose for executing the transaction. After looking up the nonce of the signer at that specific channel it will be incremented by 1 `++`.<br>
 
 For sequential messages, users could use channel `0` and for out-of-order messages they could use channel `n`.
 
 **Important:** It's up to the user to choose the channel that he wants to sign multiple sequential orders on it, not necessary `0`.
 
+
 ## Rationale
-
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-
 This standard was inspired by how files permissions are designed in UNIX based file systems.
 
 Files are assigned permissions as a 3 digit numbers, where each of the 3 digits is an octal value representing a set of permissions.
-The octal value is calculated as the sum of permissions, where _read_ = **4**, _write_ = **2**, and _execute_ = **1**
+The octal value is calculated as the sum of permissions, where *read* = **4**, *write* = **2**, and *execute* = **1**
 
-To illustrate, for a file set with permission `755`, the group permission (second digit) would be _read_ and _execute_ (See figure below). Each number is simply a **three binary placeholder, each one holding the number that correspond to the access level in r, w, x order**.
+To illustrate, for a file set with permission `755`, the group permission (second digit) would be *read* and *execute* (See figure below). Each number is simply a **three binary placeholder, each one holding the number that correspond to the access level in r, w, x order**.
+
 
 ## Implementation
-
 <!--The implementations must be completed before any LIP is given status "Final", but it need not be completed before the LIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
 
 A implementation can be found in the [lukso-network/universalprofile-smart-contracts](https://github.com/lukso-network/universalprofile-smart-contracts/blob/main/contracts/LSP3Account.sol);
@@ -268,34 +280,34 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
 
 ```json
 [
-  {
-    "name": "AddressPermissions:Permissions:<address>",
-    "key": "0x4b80742d0000000082ac0000<address>",
-    "keyType": "AddressMappingWithGrouping",
-    "valueContent": "BitArray",
-    "valueType": "bytes4"
-  },
-  {
-    "name": "AddressPermissions:AllowedAddresses:<address>",
-    "key": "0x4b80742d00000000c6dd0000<address>",
-    "keyType": "AddressMappingWithGrouping",
-    "valueContent": "Address",
-    "valueType": "address[]"
-  },
-  {
-    "name": "AddressPermissions:AllowedFunctions:<address>",
-    "key": "0x4b80742d000000008efe0000<address>",
-    "keyType": "AddressMappingWithGrouping",
-    "valueContent": "Bytes4",
-    "valueType": "bytes4[]"
-  },
-  {
-    "name": "AddressPermissions:AllowedStandards:<address>",
-    "key": "0x4b80742d000000003efa0000<address>",
-    "keyType": "AddressMappingWithGrouping",
-    "valueContent": "Bytes4",
-    "valueType": "bytes4[]"
-  }
+    {
+        "name": "AddressPermissions:Permissions:<address>",
+        "key": "0x4b80742d0000000082ac0000<address>",
+        "keyType": "AddressMappingWithGrouping",
+        "valueContent": "BitArray",
+        "valueType": "bytes4"
+    },
+    {
+        "name": "AddressPermissions:AllowedAddresses:<address>",
+        "key": "0x4b80742d00000000c6dd0000<address>",
+        "keyType": "AddressMappingWithGrouping",
+        "valueContent": "Address",
+        "valueType": "address[]"
+    },
+    {
+        "name": "AddressPermissions:AllowedFunctions:<address>",
+        "key": "0x4b80742d000000008efe0000<address>",
+        "keyType": "AddressMappingWithGrouping",
+        "valueContent": "Bytes4",
+        "valueType": "bytes4[]"
+    },
+    {
+        "name": "AddressPermissions:AllowedStandards:<address>",
+        "key": "0x4b80742d000000003efa0000<address>",
+        "keyType": "AddressMappingWithGrouping",
+        "valueContent": "Bytes4",
+        "valueType": "bytes4[]"
+    }
 ]
 ```
 
@@ -304,21 +316,21 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
 ```solidity
 
 interface ILSP6  /* is ERC165 */ {
-
-    event Executed(uint256 indexed  _value, bytes _data);
-
-
+        
+    event Executed(uint256 indexed  _value, bytes _data); 
+    
+    
     function getNonce(address _address) external view returns (uint256);
-
+    
     function execute(bytes calldata _data) external payable returns (bool);
-
+    
     function executeRelayCall(bytes calldata _data, address _signedFor, uint256 _nonce, bytes memory _signature) external payable returns (bool);
-
-
+ 
+        
     // ERC1271
-
+    
     function isValidSignature(bytes32 _hash, bytes memory _signature) external view returns (bytes4 magicValue);
-
+    
 }
 
 ```

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -220,7 +220,7 @@ Nonces are represented as `uint256` from the concatenation of two `uint128` : th
 - left most 128 bits : `channelId`
 - right most 128 bits: `nonceId`
 
-![multi-channel-nonce](https://user-images.githubusercontent.com/86341666/132648960-297b1803-0c36-413d-be44-6fa7ea709c13.jpeg)
+![multi-channel-nonce](https://user-images.githubusercontent.com/86341666/31145285/133279354-82bebc4f-21f4-40e4-b959-93ccd624e5c4.jpg)
 
 <p align="center"><i> Example of multi channel nonce, where channelId = 5 and nonceId = 1 </i></p>
 
@@ -271,28 +271,28 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
   {
     "name": "AddressPermissions:Permissions:<address>",
     "key": "0x4b80742d0000000082ac0000<address>",
-    "keyType": "Singleton",
+    "keyType": "AddressMappingWithGrouping",
     "valueContent": "BitArray",
     "valueType": "bytes4"
   },
   {
     "name": "AddressPermissions:AllowedAddresses:<address>",
     "key": "0x4b80742d00000000c6dd0000<address>",
-    "keyType": "Singleton",
+    "keyType": "AddressMappingWithGrouping",
     "valueContent": "Address",
     "valueType": "address[]"
   },
   {
     "name": "AddressPermissions:AllowedFunctions:<address>",
     "key": "0x4b80742d000000008efe0000<address>",
-    "keyType": "Singleton",
+    "keyType": "AddressMappingWithGrouping",
     "valueContent": "Bytes4",
     "valueType": "bytes4[]"
   },
   {
     "name": "AddressPermissions:AllowedStandards:<address>",
     "key": "0x4b80742d000000003efa0000<address>",
-    "keyType": "Singleton",
+    "keyType": "AddressMappingWithGrouping",
     "valueContent": "Bytes4",
     "valueType": "bytes4[]"
   }

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -32,7 +32,7 @@ Such actions are represented as permissions that can be assigned to any third pa
 
 
 ## Motivation
-<!--The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
+<!--The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.--> 
 
 ERC725 accounts enable to own a universal profile, that:
 * can hold multiple assets (tokens, NFTs...).


### PR DESCRIPTION
Fixes errors in LSP2 and LSP6 specs

# Proposed Changes

- Disable Prettier on Markdown files, so to make it easier to track LSP spec changes (otherwise, Prettier apply automatic formatting, white spaces, etc...)

## LSP2 - ERC725Y JSON Schema

- changed from  ❌  `LSP2IssuedAssets[]` to  ✅  **`LSP3IssuedAssets[]`** +  changed `keccak256` hashes in spec.



## LSP6 - KeyManager

- Added `AddressPermissions[]` key in spec.
- Edited Permission keys type from _Singleton_ to _AddressMappingWithGrouping_
- Added requirements for signature in `executeRelayCall` (packed encoded + use EIP712 Ethereum specific signature)
- Made image size smaller for multi channel nonce.