### PR TITLE
Order of params for executeRelayCall + Fixed Interface Sheetcheat

### DIFF
--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -188,7 +188,7 @@ Below is an example of a mapping key type:
 ```js
 {
     "name": "AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe",
-    "key": "0x4b80742d00000000eced0000cafecafecafecafecafecafecafecafecafecafe",
+    "key": "0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "AddressMappingWithGrouping",
     "valueContent": mixed,
     "valueType": mixed

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -248,7 +248,8 @@ The Key Manager allows out-of-order execution of messages by using nonces throug
  - left most 128 bits : `channelId`
  - right most 128 bits: `nonceId`
 
-![multi-channel-nonce](https://user-images.githubusercontent.com/86341666/31145285/133279354-82bebc4f-21f4-40e4-b959-93ccd624e5c4.jpg)
+
+![multi-channel-nonce](https://user-images.githubusercontent.com/31145285/133292580-42817340-104e-48c5-832b-533842b98d26.jpg)
 
 <p align="center"><i> Example of multi channel nonce, where channelId = 5 and nonceId = 1 </i></p>
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -192,16 +192,16 @@ Read [what are multi-channel nonces](#what-are-multi-channel-nonces)
 #### executeRelayCall
 
 ```solidity
-function executeRelayCall(bytes calldata _data, address _signedFor, uint256 _nonce, bytes memory _signature) public payable returns (bool)
+function executeRelayCall(address _signedFor, uint256 _nonce, bytes calldata _data, bytes memory _signature) public payable returns (bool)
 ```
 
 Allows anybody to execute `_data` payload on a ERC725 account, given they have a signed message from an executor.
 
 **Parameters:**
 
-- `_data`: The call data to be executed.
 - `_signedFor`: MUST be the `KeyManager` contract.
 - `_nonce`: MUST be the nonce of the address that signed the message. This can be obtained via the `getNonce(address _address, uint256 _channel)` function.
+- `_data`: The call data to be executed.
 - `_signature`: bytes32 ethereum signature.
 
 **returns:** `bool` , true if the call on ERC725 account succeeded, false otherwise.
@@ -335,11 +335,11 @@ interface ILSP6  /* is ERC165 */ {
     event Executed(uint256 indexed  _value, bytes _data); 
     
     
-    function getNonce(address _address) external view returns (uint256);
+    function getNonce(address _address, uint256 _channel) external view returns (uint256);
     
     function execute(bytes calldata _data) external payable returns (bool);
     
-    function executeRelayCall(bytes calldata _data, address _signedFor, uint256 _nonce, bytes memory _signature) external payable returns (bool);
+    function executeRelayCall(address _signedFor, uint256 _nonce, bytes calldata _data, bytes memory _signature) external payable returns (bool);
  
         
     // ERC1271


### PR DESCRIPTION
- [x] changed order of `executeRelayCall` function parameters. `_data` moved from 1st to 3rd parameter.
- [x] fixed error in LSP2 for `**AddressMappingWithGrouping** (incorrect value for `bytes2(SecondWord)`)
- [x] Added `_channel` parameter for `getNonce` in **Interface Sheetcheat** 

@YamenMerhi @frozeman , for the function `getNonce(...)` (in both the **Methods** and **Interface SheetCheat**), should we put the`_channel` parameter as `uint128` instead of `uint256`?
This would align with what is mentioned above the figure in [**Nonces in the KeyManager**](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-6-KeyManager.md#nonces-in-the-keymanager)