### PR TITLE
Add SupportedStandards:LSP6KeyManager in LSP6

### DIFF
--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -86,7 +86,7 @@ An initial key of an array containing the array length constructed using `bytes3
 Subsequent keys consist of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`.
 
 *The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
-Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit.*
+Storing an encoded array as a value, will require a set amount of gas, which can exceed the block gas limit.*
 
 If you require multiple keys of the same key type they MUST be defined as follows:
 

--- a/LSPs/LSP-3-UniversalProfile.md
+++ b/LSPs/LSP-3-UniversalProfile.md
@@ -24,7 +24,7 @@ This standard describes meta data that can be added to a [ERC725Account](https:/
 
 ## Specification
 
-Every contract that supports to the Universal Profile standard SHOULD add the following [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) keys:
+Every contract that supports the Universal Profile standard SHOULD add the following [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) keys:
 
 ### Keys
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -49,6 +49,23 @@ What is required is a contract design that enable ERC725 account owners to:
 
 ## Specification
 
+Every contract that supports the Key Manager standard SHOULD add the following [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) keys:
+
+### Keys
+
+#### SupportedStandards:LSP6KeyManager
+
+The supported standard SHOULD be `LSP6KeyManager`
+
+```json
+{
+    "name": "SupportedStandards:LSP6KeyManager",
+    "key": "0xeafec4d89fa9619884b6b891356264550000000000000000000000006d9de44d",
+    "keyType": "Mapping",
+    "valueContent": "0x6d9de44d",
+    "valueType": "bytes"
+}
+```
 
 ### Permission Keys on the ERC725Account
 


### PR DESCRIPTION
The KeyManager smart contract supports ERC725Y.
The current LSP6 describes how the ERC725Y keys should be defined on the ERC725Account smart contract, but does not describe any keys on the KeyManager smart contract itself.

This change suggests to add the following key to the KeyManager smart contract:

```json
{
    "name": "SupportedStandards:LSP6KeyManager",
    "key": "0xeafec4d89fa9619884b6b891356264550000000000000000000000006d9de44d",
    "keyType": "Mapping",
    "valueContent": "0x6d9de44d",
    "valueType": "bytes"
}
```

So it stays consistent with other LSP:

- `SupportedStandards:LSP3UniversalProfile`
- `SupportedStandards:LSP4DigitalCertificate`