### PR TITLE
Standards Changes

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -111,9 +111,9 @@ interface ILSP0  /* is ERC165 */ {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
 
-    function owner() external view virtual returns (address);
+    function owner() external view returns (address);
     
-    function transferOwnership(address newOwner) external virtual onlyOwner;
+    function transferOwnership(address newOwner) external;
     
     
     // ERC725Account (ERC725X + ERC725Y)
@@ -127,13 +127,13 @@ interface ILSP0  /* is ERC165 */ {
     event DataChanged(bytes32 indexed key, bytes value);
     
     
-    function execute(uint256 operationType, address to, uint256 value, bytes calldata data) external payable onlyOwner;
+    function execute(uint256 operationType, address to, uint256 value, bytes calldata data) external payable returns (bytes memory);
     
-    function getData(bytes32[] calldata key) external view returns (bytes[] memory value);
+    function getData(bytes32[] memory key) external view returns (bytes[] memory value);
     // LSP0 possible keys:
     // LSP1UniversalReceiverDelegate: 0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47
     
-    function setData(bytes32[] calldata key, bytes[] calldata value) external onlyOwner;
+    function setData(bytes32[] memory key, bytes[] memory value) external;
     
     
     // ERC1271
@@ -145,7 +145,7 @@ interface ILSP0  /* is ERC165 */ {
 
     event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes32 indexed returnedValue, bytes receivedData);
 
-    function universalReceiver(bytes32 typeId, bytes calldata data) external returns (bytes32);
+    function universalReceiver(bytes32 typeId, bytes calldata data) external returns (bytes memory);
     // IF `LSP1UniversalReceiverDelegate` key is set
     // THEN calls will be forwarded to the address given (UniversalReceiver even MUST still be fired)
 }

--- a/LSPs/LSP-1-UniversalReceiver.md
+++ b/LSPs/LSP-1-UniversalReceiver.md
@@ -40,18 +40,18 @@ Every contract that complies to the Universal Receiver standard MUST implement:
 #### universalReceiver
 
 ```solidity
-universalReceiver(bytes32 typeId, bytes data) public returns (bytes32)
+universalReceiver(bytes32 typeId, bytes data) public returns (bytes memory)
 ```
 
 Allows to be called by any external contract to inform the contract about any incoming transfers, interactions or simple information.
 
-**Parameters:**
+_Parameters:_
 
 - `bytes32 typeId` is the hash of a standard (according to ERC165?)
 
 - `bytes data` is a byteArray of arbitrary data. Reciving contracts should take the `id` in consideration to properly decode the `data`. The function MUST revert if `id` is not accepted or unknown. 
 
-**returns:** `bytes32`, which can be used to encode response values.
+_Returns:_  `bytes`, which can be used to encode response values.
 
 **If the receiving should fail the function MUST revert.**
 
@@ -61,7 +61,7 @@ Allows to be called by any external contract to inform the contract about any in
 #### UniversalReceiver
 
 ```solidity
-event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes32 indexed returnedValue, bytes receivedData)
+event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData)
 ```
 
 This event MUST be emitted when the `universalReceiver` function is succesfully executed.
@@ -75,12 +75,12 @@ ERC165 interface id: `0xc2d7bcc1`
 
 
 ```solidity
-universalReceiverDelegate(address sender, bytes32 typeId, bytes memory data) public returns (bytes32);
+universalReceiverDelegate(address sender, bytes32 typeId, bytes memory data) public returns (bytes memory);
 ```
 
 Allows to be called by any external contract when an address wants to delegate its universalReceiver functionality to another smart contract.
 
-**Parameters:**
+_Parameters:_
 
 - `sender` is the address delegating his universalReceiver functionality.
 
@@ -88,7 +88,7 @@ Allows to be called by any external contract when an address wants to delegate i
 
 - `data` is a byteArray of arbitrary data. Reciving contracts should take the `id` in consideration to properly decode the `data`. The function MUST revert if `id` is not accepted or unknown.
 
-**returns:** `bytes32`, which can be used to encode response values.
+_Returns:_  `bytes`, which can be used to encode response values.
 
 **If the receiving should fail the function MUST revert.**
 
@@ -109,9 +109,9 @@ pragma solidity >=0.5.0 <0.7.0;
 
 // ERC 165 interface id: `0x6bb56a14`
 interface ILSP1 {
-    event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes32 indexed returnedValue, bytes receivedData);
+    event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
 
-    function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes32);
+    function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory);
 }
 ```
 
@@ -124,7 +124,7 @@ without changing its own code.
 // ERC 165 interface id: `0xc2d7bcc1`
 interface ILSP1Delegate  /* is ERC165 */ {
 
-    function universalReceiverDelegate(address sender, bytes32 typeId, bytes memory data) public returns (bytes32);
+    function universalReceiverDelegate(address sender, bytes32 typeId, bytes memory data) public returns (bytes memory);
 }
 
 ```
@@ -145,7 +145,7 @@ contract BasicUniversalReceiver is ERC165, ILSP1 {
         _registerInterface(_INTERFACE_ID_LSP1);
     }
 
-    function universalReceiver(bytes32 typeId, bytes memory data) public returns (bytes32) {
+    function universalReceiver(bytes32 typeId, bytes memory data) public returns (bytes memory) {
         emit UniversalReceiver(msg.sender, typeId, 0x0, data);
         return 0x0;
     }
@@ -174,7 +174,7 @@ contract ExternalUniversalReceiver is ERC165, ILSP1 {
         universalReceiverDelegate = _universalReceiverDelegate;
     }
 
-    function universalReceiver(bytes32 _typeId, bytes memory _data) public returns (bytes32 returnValue) {
+    function universalReceiver(bytes32 _typeId, bytes memory _data) public returns (bytes memory returnValue) {
 
         if (ERC165(universalReceiverDelegate).supportsInterface(_INTERFACE_ID_LSP1DELEGATE)) {
             returnValue = ILSP1Delegate(universalReceiverDelegate).universalReceiverDelegate(_msgSender(), _typeId, _data);
@@ -198,14 +198,14 @@ contract UniversalReceiverDelegate is ERC165, ILSP1Delegate {
         _registerInterface(_INTERFACE_ID_LSP1DELEGATE);
     }
 
-    function universalReceiverDelegate(address sender, bytes32 typeId, bytes memory data) public override returns (bytes32) {
+    function universalReceiverDelegate(address sender, bytes32 typeId, bytes memory data) public override returns (bytes memory) {
         require(typeId == _TOKENS_RECIPIENT_INTERFACE_HASH, 'UniversalReceiverDelegate: Type not supported');
 
         // lets store all incoming token address (this is simplistic, you want to use a enumerableSet)
         // An example implementation can be found at https://github.com/lukso-network/standards-scenarios/blob/master/contracts/UniversalReceiver/UniversalReceiverAddressStore.sol
         addressStore.push(sender);
 
-        return typeId;
+        return abi.encodePacked(typeId);
     }
 }
 ```
@@ -232,7 +232,7 @@ contract UniversalReceiverExample is BasicUniversalReceiver {
         }
     }
 
-    function universalReceiver(bytes32 typeId, bytes calldata data) public returns (bytes32) {
+    function universalReceiver(bytes32 typeId, bytes calldata data) public returns (bytes memory) {
         if(typeId == TOKEN_RECEIVE){
             (address from, address to, uint256 amount) = toTokenData(data);
             emit TokenReceived(msg.sender, from, to, amount);
@@ -251,15 +251,15 @@ contract UniversalReceiverExample is BasicUniversalReceiver {
 
 interface ILSP1  /* is ERC165 */ {
 
-    event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes32 indexed returnedValue, bytes receivedData);
+    event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
     
-    function universalReceiver(bytes32 typeId, bytes calldata data) external returns (bytes32);
+    function universalReceiver(bytes32 typeId, bytes calldata data) external returns (bytes memory);
     
 }
     
 interface ILSP1Delegate  /* is ERC165 */ {
     
-    function universalReceiverDelegate(address sender, bytes32 typeId, bytes memory data) external returns (bytes32);
+    function universalReceiverDelegate(address sender, bytes32 typeId, bytes memory data) external returns (bytes memory);
 
 }
 ```

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -154,18 +154,18 @@ SIGN          = 0x80;   // 1000 0000
 #### execute
 
 ```solidity
-function execute(bytes calldata _data) public payable returns (bool)
+function execute(bytes calldata _data) public payable returns (bytes memory)
 ```
 
 Execute a calldata payload on an ERC725 account.
 
 MUST fire the [Executed event](#executed).
 
-**Parameters:**
+_Parameters:_
 
 - `_data`: The call data to be executed. The first 4 bytes of the `_data` payload MUST correspond to one of the function selector in the ERC725 account, such as `setData(...)`, `execute(...)` or `transferOwnership(...)`.
 
-**returns:** `bool` , `true` if the call on ERC725 account succeeded, `false` otherwise.
+_Returns:_ `bytes` , returned from the function called.
 
 
 
@@ -182,33 +182,33 @@ If multiple transactions should be signed, nonces in the same channel can simply
 
 Read [what are multi-channel nonces](#what-are-multi-channel-nonces)
 
-**Parameters:**
+_Parameters:_
 
 - `_address`: the address of the signer of the transaction.
 - `_channel` :  the channel which the signer wants to use for executing the transaction.
 
-**returns:** `uint256` , returns the current nonce.
+_Returns:_ `uint256` , returns the current nonce.
 
 
 
 #### executeRelayCall
 
 ```solidity
-function executeRelayCall(address _signedFor, uint256 _nonce, bytes calldata _data, bytes memory _signature) public payable returns (bool)
+function executeRelayCall(address _signedFor, uint256 _nonce, bytes calldata _data, bytes memory _signature) public payable returns (bytes memory)
 ```
 
 Allows anybody to execute `_data` payload on a ERC725 account, given they have a signed message from an executor.
 
 MUST fire the [Executed event](#executed).
 
-**Parameters:**
+_Parameters:_
 
 - `_signedFor`: MUST be the `KeyManager` contract.
 - `_nonce`: MUST be the nonce of the address that signed the message. This can be obtained via the `getNonce(address _address, uint256 _channel)` function.
 - `_data`: The call data to be executed.
 - `_signature`: bytes32 ethereum signature.
 
-**returns:** `bool` , true if the call on ERC725 account succeeded, false otherwise.
+_Returns:_ `bytes` , returned from the function called.
 
 **Important:** the message to sign MUST be of the following format: `<KeyManager address>` + `<signer nonce>` + `<_data payload>` .
 These 3 parameters MUST be:
@@ -283,9 +283,9 @@ _nonces[signer][nonce >> 128]++
 ```
 `nonce >> 128` represents the channel which the signer chose for executing the transaction. After looking up the nonce of the signer at that specific channel it will be incremented by 1 `++`.<br>
 
-For sequential messages, users could use channel `0` and for out-of-order messages they could use channel `n`.
+For sequential messages, users could use channel `0` and for out-of-order messages they could use channel `n`.
 
-**Important:** It's up to the user to choose the channel that he wants to sign multiple sequential orders on it, not necessary `0`.
+**Important:** It's up to the user to choose the channel that he wants to sign multiple sequential orders on it, not necessary `0`.
 
 
 
@@ -351,9 +351,9 @@ interface ILSP6  /* is ERC165 */ {
     
     function getNonce(address _address, uint256 _channel) external view returns (uint256);
     
-    function execute(bytes calldata _data) external payable returns (bool);
+    function execute(bytes calldata _data) external payable returns (bytes memory);
     
-    function executeRelayCall(address _signedFor, uint256 _nonce, bytes calldata _data, bytes memory _signature) external payable returns (bool);
+    function executeRelayCall(address _signedFor, uint256 _nonce, bytes calldata _data, bytes memory _signature) external payable returns (bytes memory);
  
         
     // ERC1271


### PR DESCRIPTION
- Remove modifier + virtual keywords
- Italic text (returns, parameters)
- `Calldata` to `memory` in ERC725Y
- Return from `bytes32` to `bytes` in universal receiver
- Return from bool to `bytes`  in execute/executeRelayCall