### PR TITLE
Fix header issue in LSP6

### DIFF
--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -1,4 +1,4 @@
-****---
+---
 lip: 6
 title: Key Manager
 author: Fabian Vogelsteller <fabian@lukso.network>, Jean Cavallera <contact.cj42@protonmail.com>


### PR DESCRIPTION
The header in LSP6 does not display correctly anymore.

See here: https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md

This PR fixes it.