### PR TITLE
docs: switch from `asset` to `token` keyword

### DIFF
--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -55,7 +55,7 @@ function totalSupply() external view returns (uint256);
 
 Returns the number of existing tokens.
 
-**Returns:** `uint256` the number of existing assets.
+**Returns:** `uint256` the number of existing tokens.
 
 #### balanceOf
 ```solidity
@@ -68,7 +68,7 @@ _Parameters:_
 
 - `tokenOwner` the address to query.
 
-**Returns:** `uint256` the number of assets owned by this address.
+**Returns:** `uint256` the number of tokens owned by this address.
 
 #### authorizeOperator
 

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -173,7 +173,7 @@ function totalSupply() external view returns (uint256);
 
 Returns the number of existing tokens.
 
-**Returns:** `uint256` the number of existing assets.
+**Returns:** `uint256` the number of existing tokens.
 
 #### balanceOf
 ```solidity
@@ -186,7 +186,7 @@ _Parameters:_
 
 - `tokenOwner` the address to query.
 
-**Returns:** `uint256` the number of assets owned by this address.
+**Returns:** `uint256` the number of tokens owned by this address.
 
 #### tokenOwnerOf
 


### PR DESCRIPTION
# What does this PR introduce?

- Small PR to sync the content of docs.lukso.tech with the current standards, as the word `token` should be used in the LSP7/8 function and not `asset`