### PR TITLE
LSP4: fix old deprecated `SupportedStandards` key-value pair

### DIFF
--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -36,10 +36,10 @@ The supported standard SHOULD be `LSP4DigitalCertificate`
 
 ```json
 {
-    "name": "SupportedStandards:LSP4DigitalCertificate",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abf0613c",
+    "name": "SupportedStandards:LSP4DigitalAsset",
+    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
     "keyType": "Mapping",
-    "valueContent": "0xabf0613c",
+    "valueContent": "0xa4d96624",
     "valueType": "bytes"
 }
 ```
@@ -199,9 +199,9 @@ ERC725Y JSON Schema `LSP4DigitalCertificate`:
 [
     {
         "name": "SupportedStandards:LSP4DigitalCertificate",
-        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abf0613c",
+        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
         "keyType": "Mapping",
-        "valueContent": "0xabf0613c",
+        "valueContent": "0xa4d96624",
         "valueType": "bytes"
     },
     {

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -30,9 +30,9 @@ An LSP4 asset is controlled by a single `owner`, expected to be a ERC725 smart c
 
 ### ERC725Y Keys
 
-#### SupportedStandards:LSP4DigitalCertificate
+#### SupportedStandards:LSP4DigitalAsset
 
-The supported standard SHOULD be `LSP4DigitalCertificate`
+The supported standard SHOULD be `LSP4DigitalAsset`
 
 ```json
 {
@@ -99,14 +99,14 @@ The linked JSON file SHOULD have the following format:
 {
     "LSP4Metadata": {
         "description": "string",
-        "links": [ // links related to DigitalCertificate
+        "links": [ // links related to DigitalAsset
             {
                 "title": "string", // a title for the link.
                 "url": "string" // the link itself
             },
             ...
         ],  
-        "images": [ // multiple images in different sizes, related to the DigitalCertificate, image 0, should be the main image
+        "images": [ // multiple images in different sizes, related to the DigitalAsset, image 0, should be the main image
             [
                 {
                     "width": Number,
@@ -191,14 +191,14 @@ There can be many token implementations, and this standard fills a need for comm
 ## Implementation
 
 A implementation can be found in the [lukso-network/universalprofile-smart-contracts](https://github.com/lukso-network/universalprofile-smart-contracts/blob/main/contracts/LSP4/LSP4.sol);
-The below defines the JSON interface of the `LSP4DigitalCertificate`.
+The below defines the JSON interface of the `LSP4DigitalAsset`.
 
-ERC725Y JSON Schema `LSP4DigitalCertificate`:
+ERC725Y JSON Schema `LSP4DigitalAsset`:
 
 ```json
 [
     {
-        "name": "SupportedStandards:LSP4DigitalCertificate",
+        "name": "SupportedStandards:LSP4DigitalAsset",
         "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
         "keyType": "Mapping",
         "valueContent": "0xa4d96624",


### PR DESCRIPTION
# What does this PR introduce?

LSP4 is now Digital**Asset** (before Digital~Certificate~)

Therefore replace first 4 bytes of keccak256 hash of the word as below:

`SupportedStandards:LSP4DigitalCertificate` > `0xabf0613c` ❌  
`SupportedStandards:LSP4DigitalAsset` > **`0xa4d96624`** ✅ 

+  all occurences of word ~_"Certificate"_~ by _**"Asset"**_