### PR TITLE
fix: return types for LSP6

### DIFF
--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -146,6 +146,24 @@ SIGN               = 0x000000000000000000000000000000000000000000000000000000000
 ### Methods
 
 
+#### getNonce
+
+```solidity
+function getNonce(address _address, uint256 _channel) public view returns (uint256)
+```
+
+Returns the nonce that needs to be signed by a allowed key to be passed into the [executeRelayCall](#executeRelayCall) function. A signer can choose his channel number arbitrarily.
+
+If multiple transactions should be signed, nonces in the same channel can simply be increased by increasing the returned nonce.
+
+Read [what are multi-channel nonces](#what-are-multi-channel-nonces)
+
+_Parameters:_
+
+- `_address`: the address of the signer of the transaction.
+- `_channel` :  the channel which the signer wants to use for executing the transaction.
+
+_Returns:_ `uint256` , the current nonce.
 
 #### execute
 
@@ -166,24 +184,6 @@ _Returns:_ `bytes` , the returned data as abi-encoded bytes if the call on ERC72
 
 
 
-#### getNonce
-
-```solidity
-function getNonce(address _address, uint256 _channel) public view returns (uint256)
-```
-
-Returns the nonce that needs to be signed by a allowed key to be passed into the [executeRelayCall](#executeRelayCall) function. A signer can choose his channel number arbitrarily.
-
-If multiple transactions should be signed, nonces in the same channel can simply be increased by increasing the returned nonce.
-
-Read [what are multi-channel nonces](#what-are-multi-channel-nonces)
-
-_Parameters:_
-
-- `_address`: the address of the signer of the transaction.
-- `_channel` :  the channel which the signer wants to use for executing the transaction.
-
-_Returns:_ `uint256` , the current nonce.
 
 
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -168,7 +168,7 @@ _Returns:_ `uint256` , the current nonce.
 #### execute
 
 ```solidity
-function execute(bytes memory _data) public payable returns (bool)
+function execute(bytes memory _data) public payable returns (bytes memory)
 ```
 
 Execute a payload on an ERC725 account.
@@ -190,7 +190,7 @@ _Returns:_ `bytes` , the returned data as abi-encoded bytes if the call on ERC72
 #### executeRelayCall
 
 ```solidity
-function executeRelayCall(address _signedFor, uint256 _nonce, bytes memory _data, bytes memory _signature) public payable returns (bool)
+function executeRelayCall(address _signedFor, uint256 _nonce, bytes memory _data, bytes memory _signature) public payable returns (bytes memory)
 ```
 
 Allows anybody to execute `_data` payload on a ERC725 account, given they have a signed message from an executor.
@@ -354,9 +354,9 @@ interface ILSP6  /* is ERC165 */ {
     
     function getNonce(address _address, uint256 _channel) external view returns (uint256);
     
-    function execute(bytes memory _data) external payable returns (bool);
+    function execute(bytes memory _data) external payable returns (bytes memory);
     
-    function executeRelayCall(address _signedFor, uint256 _nonce, bytes memory _data, bytes memory _signature) external payable returns (bool);
+    function executeRelayCall(address _signedFor, uint256 _nonce, bytes memory _data, bytes memory _signature) external payable returns (bytes memory);
  
         
     // ERC1271


### PR DESCRIPTION
# What does this PR introduce?

- fix return types in LSP6 from `returns (bool)` to `returns (bytes memory)`.
- changed order of method, putting `getNonce` first.