### PR TITLE
Docs/array maps

### DIFF
--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -168,7 +168,7 @@ For more infos about accessing each index of the `LSP3IssuedAssets[]` array, see
 
 References issued smart contract assets, like tokens and NFTs.
 
-The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where `indexNumber` is the index in the [LSP3IssuedAssets[] Array](#lsp3issuedassets) and `standardInterfaceId` the interface ID if the token or asset smart contract standard.
+The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where `indexNumber` is the index in the [`LSP3IssuedAssets[]` Array](#lsp3issuedassets) and `standardInterfaceId` the interface ID if the token or asset smart contract standard.
 
 ```json
 {

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -168,7 +168,9 @@ For more infos about accessing each index of the `LSP3IssuedAssets[]` array, see
 
 References issued smart contract assets, like tokens and NFTs.
 
-The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where `indexNumber` is the index in the [`LSP3IssuedAssets[]` Array](#lsp3issuedassets) and `standardInterfaceId` the interface ID if the token or asset smart contract standard.
+The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where:
+- `indexNumber` = the index in the [`LSP3IssuedAssets[]` Array](#lsp3issuedassets)
+- `standardInterfaceId` = the interface ID if the token or asset smart contract standard.
 
 ```json
 {

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -170,7 +170,7 @@ References issued smart contract assets, like tokens and NFTs.
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where:
 - `indexNumber` = the index in the [`LSP3IssuedAssets[]` Array](#lsp3issuedassets)
-- `standardInterfaceId` = the interface ID if the token or asset smart contract standard.
+- `standardInterfaceId` = the ERC165 interface ID of the standard that the token or asset smart contract implements.
 
 ```json
 {

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -180,7 +180,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 }
 ```
 
-For construction of the Asset Keys see: [ERC725Y JSON Schema](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about accessing each index of the `LSP3IssuedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 ## Rationale
 

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -150,7 +150,7 @@ Example:
 
 #### LSP3IssuedAssets[]
 
-An array of smart contract assets issued by the Universal Profile, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
+An array of smart contract assets issued by the Universal Profile, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
 
 ```json
 {
@@ -166,7 +166,7 @@ For more infos about how to access each index of the `LSP3IssuedAssets[]` array,
 
 #### LSP3IssuedAssetsMap
 
-References issued smart contract assets, like tokens (_e.g.:_ _[LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.:_ _[LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
+References issued smart contract assets, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where:
 - `indexNumber` = the index in the [`LSP3IssuedAssets[]` Array](#lsp3issuedassets)

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -150,7 +150,7 @@ Example:
 
 #### LSP3IssuedAssets[]
 
-An array of smart contract assets issued by the Universal Profile, like tokens and NFTs.
+An array of smart contract assets issued by the Universal Profile, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
 
 ```json
 {
@@ -162,11 +162,11 @@ An array of smart contract assets issued by the Universal Profile, like tokens a
 }
 ```
 
-For more infos about accessing each index of the `LSP3IssuedAssets[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about how to access each index of the `LSP3IssuedAssets[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### LSP3IssuedAssetsMap
 
-References issued smart contract assets, like tokens and NFTs.
+References issued smart contract assets, like tokens (_e.g.:_ _[LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.:_ _[LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where:
 - `indexNumber` = the index in the [`LSP3IssuedAssets[]` Array](#lsp3issuedassets)
@@ -182,7 +182,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 }
 ```
 
-For more infos about accessing each index of the `LSP3IssuedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about how to access each index of the `LSP3IssuedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 ## Rationale
 

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -170,7 +170,7 @@ References issued smart contract assets, like tokens (_e.g.: [LSP7 Digital Asset
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where:
 - `indexNumber` = the index in the [`LSP3IssuedAssets[]` Array](#lsp3issuedassets)
-- `standardInterfaceId` = the ERC165 interface ID of the standard that the token or asset smart contract implements.
+- `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements.
 
 ```json
 {

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -150,7 +150,7 @@ Example:
 
 #### LSP3IssuedAssets[]
 
-References issued smart contract assets, like tokens and NFTs.
+An array of smart contract assets issued by the Universal Profile, like tokens and NFTs.
 
 ```json
 {
@@ -161,6 +161,8 @@ References issued smart contract assets, like tokens and NFTs.
     "valueType": "address"
 }
 ```
+
+For more infos about accessing each index of the `LSP3IssuedAssets[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### LSP3IssuedAssetsMap
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -186,8 +186,8 @@ References the creator addresses for this asset.
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. 
 Where:
-- `indexNumber` = the index in the [LSP4Creators[] Array](#lsp3issuedassets)
-- `standardInterfaceId` = the interface ID of the creator smart contract standard.
+- `indexNumber` = the index in the [`LSP4Creators[]` Array](#lsp3issuedassets)
+- `standardInterfaceId` = if the creator address is a smart contract, the ERC165 interface ID of the standard that the smart contract implements. Otherwise `0x00000000`
 
 ```json
 {

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -184,7 +184,10 @@ For more infos about accessing each index of the `LSP4Creators[]` array, see [ER
 
 References the creator addresses for this asset.
 
-The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where `indexNumber` is the index in the [LSP4Creators[] Array](#lsp3issuedassets) and `standardInterfaceId` the interface ID of the creator smart contract standard.
+The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. 
+Where:
+- `indexNumber` = the index in the [LSP4Creators[] Array](#lsp3issuedassets)
+- `standardInterfaceId` = the interface ID of the creator smart contract standard.
 
 ```json
 {
@@ -235,6 +238,13 @@ ERC725Y JSON Schema `LSP4DigitalAsset`:
         "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
         "keyType": "Singleton",
         "valueContent": "JSONURL",
+        "valueType": "bytes"
+    },
+    {
+        "name": "LSP4CreatorsMap:<address>",
+        "key": "0x6de85eaf5d982b4e00000000<address>",
+        "keyType": "Mapping",
+        "valueContent": "Mixed",
         "valueType": "bytes"
     },
     {

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -178,7 +178,7 @@ An array of ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines t
 }
 ```
 
-For more infos about accessing each index of the `LSP4Creators[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about how to access each index of the `LSP4Creators[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### LSP4CreatorsMap
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -187,7 +187,7 @@ References the creator addresses for this asset.
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. 
 Where:
 - `indexNumber` = the index in the [`LSP4Creators[]` Array](#lsp3issuedassets)
-- `standardInterfaceId` = if the creator address is a smart contract, the ERC165 interface ID of the standard that the smart contract implements. Otherwise `0x00000000`
+- `standardInterfaceId` = if the creator address is a smart contract, the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the smart contract implements. Otherwise `0x00000000`
 
 ```json
 {

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -164,7 +164,7 @@ Example:
 
 #### LSP4Creators[]
 
-An array of (ERC725Account) addresses of creators,
+An array ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines the creators of the digital asset.
 
 ```json
 {
@@ -178,7 +178,7 @@ An array of (ERC725Account) addresses of creators,
 }
 ```
 
-For construction of the Asset Keys see: [ERC725Y JSON Schema](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about accessing each index of the `LSP4Creators[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### LSP4CreatorsMap
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -182,7 +182,19 @@ For more infos about accessing each index of the `LSP4Creators[]` array, see: [E
 
 #### LSP4CreatorsMap
 
-TODO: take a look at lsp5 to get the map
+References the creator addresses for this asset.
+
+The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where `indexNumber` is the index in the [LSP4Creators[] Array](#lsp3issuedassets) and `standardInterfaceId` the interface ID of the creator smart contract standard.
+
+```json
+{
+    "name": "LSP4CreatorsMap:<address>",
+    "key": "0x6de85eaf5d982b4e00000000<address>",
+    "keyType": "Mapping",
+    "valueContent": "Mixed",
+    "valueType": "bytes"
+}
+```
 
 ## Rationale
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -164,7 +164,7 @@ Example:
 
 #### LSP4Creators[]
 
-An array ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines the creators of the digital asset.
+An array of ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines the creators of the digital asset.
 
 ```json
 {
@@ -178,7 +178,7 @@ An array ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines the 
 }
 ```
 
-For more infos about accessing each index of the `LSP4Creators[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about accessing each index of the `LSP4Creators[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### LSP4CreatorsMap
 

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -35,7 +35,8 @@ Every contract that supports to the ERC725Account SHOULD have the following keys
 
 #### LSP5ReceivedAssets[]
 
-References issued smart contract assets, like tokens and NFTs.
+An array of received smart contract assets, tokens and NFTs.
+
 
 ```json
 {
@@ -50,7 +51,7 @@ References issued smart contract assets, like tokens and NFTs.
 
 #### LSP5ReceivedAssetsMap
 
-References issued smart contract assets, like tokens and NFTs.
+References received smart contract assets, like tokens and NFTs.
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where `indexNumber` is the index in the [LSP3IssuedAssets[] Array](#lsp3issuedassets) and `standardInterfaceId` the interface ID if the token or asset smart contract standard.
 

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -35,7 +35,7 @@ Every contract that supports to the ERC725Account SHOULD have the following keys
 
 #### LSP5ReceivedAssets[]
 
-An array of received smart contract assets, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
+An array of received smart contract assets, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
 
 
 ```json
@@ -52,7 +52,7 @@ For more infos about how to access each index of the `LSP5ReceivedAssets[]` arra
 
 #### LSP5ReceivedAssetsMap
 
-References received smart contract assets, like tokens (_e.g.:_ _[LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.:_ _[LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
+References received smart contract assets, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where: 
 - `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp3issuedassets)

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -35,7 +35,7 @@ Every contract that supports to the ERC725Account SHOULD have the following keys
 
 #### LSP5ReceivedAssets[]
 
-An array of received smart contract assets, like tokens and NFTs.
+An array of received smart contract assets, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
 
 
 ```json
@@ -48,11 +48,11 @@ An array of received smart contract assets, like tokens and NFTs.
 }
 ```
 
-For more infos about accessing each index of the `LSP5ReceivedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about how to access each index of the `LSP5ReceivedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### LSP5ReceivedAssetsMap
 
-References received smart contract assets, like tokens and NFTs.
+References received smart contract assets, like tokens (_e.g.:_ _[LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.:_ _[LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where: 
 - `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp3issuedassets)

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -55,8 +55,8 @@ For more infos about accessing each index of the `LSP5ReceivedAssets[]` array, s
 References received smart contract assets, like tokens and NFTs.
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where: 
-- `indexNumber` = the index in the [LSP3IssuedAssets[] Array](#lsp3issuedassets)
-- `standardInterfaceId` = the interface ID if the token or asset smart contract standard.
+- `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp3issuedassets)
+- `standardInterfaceId` = the ERC165 interface ID of the standard that the token or asset smart contract implements.
 
 ```json
 {

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -56,7 +56,7 @@ References received smart contract assets, like tokens (_e.g.: [LSP7 Digital Ass
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where: 
 - `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp3issuedassets)
-- `standardInterfaceId` = the ERC165 interface ID of the standard that the token or asset smart contract implements.
+- `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements.
 
 ```json
 {

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -35,7 +35,7 @@ Every contract that supports to the ERC725Account SHOULD have the following keys
 
 #### LSP5ReceivedAssets[]
 
-An array of received smart contract assets, tokens and NFTs.
+An array of received smart contract assets, like tokens and NFTs.
 
 
 ```json
@@ -48,7 +48,7 @@ An array of received smart contract assets, tokens and NFTs.
 }
 ```
 
-For more infos about accessing each index of the `LSP5ReceivedAssets[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about accessing each index of the `LSP5ReceivedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### LSP5ReceivedAssetsMap
 

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -54,7 +54,9 @@ For more infos about accessing each index of the `LSP5ReceivedAssets[]` array, s
 
 References received smart contract assets, like tokens and NFTs.
 
-The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where `indexNumber` is the index in the [LSP3IssuedAssets[] Array](#lsp3issuedassets) and `standardInterfaceId` the interface ID if the token or asset smart contract standard.
+The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where: 
+- `indexNumber` = the index in the [LSP3IssuedAssets[] Array](#lsp3issuedassets)
+- `standardInterfaceId` = the interface ID if the token or asset smart contract standard.
 
 ```json
 {

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -48,6 +48,7 @@ An array of received smart contract assets, tokens and NFTs.
 }
 ```
 
+For more infos about accessing each index of the `LSP5ReceivedAssets[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### LSP5ReceivedAssetsMap
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -65,7 +65,7 @@ This is mainly useful for interfaces to know which address hold permissions.
 }
 ```
 
-For more infos about accessing each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType` `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about how to access each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType` `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### AddressPermissions:Permissions:\<address\>
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -65,7 +65,7 @@ This is mainly useful for interfaces to know which address hold permissions.
 }
 ```
 
-For more infos about accessing each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about accessing each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType` `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
 
 #### AddressPermissions:Permissions:\<address\>
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -112,7 +112,7 @@ Contains an array of bytes4 function signatures, the controlling address is allo
 
 #### AddressPermissions:AllowedStandards:\<address\>
 
-Contains an array of bytes4 ERC165 interface Ids, other smart contracts MUST support, for the controlling address to be allowed to interact with.
+Contains an array of bytes4 [ERC165 interface Ids](https://eips.ethereum.org/EIPS/eip-165), other smart contracts MUST support, for the controlling address to be allowed to interact with.
 
 ```json
 {

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -65,6 +65,8 @@ This is mainly useful for interfaces to know which address hold permissions.
 }
 ```
 
+For more infos about accessing each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+
 #### AddressPermissions:Permissions:\<address\>
 
 Contains [the permissions](#permission-values-in-addresspermissionspermissionsaddress) for an address.


### PR DESCRIPTION
# What does this PR introduce?

## Features
- added `LSP4CreatorsMap` key in LSP4

## Improvements
- improved description of ERC725Y: 
    - array keys (sentence + references)
    - map keys (broke down in bullet points + added reference to ERC165 standard).

## Fixes
- fixed array + map description in LSP5 (replaced ~issued~ by **received**  for assets).

