### PR TITLE
refactor: improve ERC725Y keys descriptions

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -58,8 +58,8 @@ this smart contract address MUST be stored under the following key:
     "name": "LSP1UniversalReceiverDelegate",
     "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
     "keyType": "Singleton",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
 }
 ```
 
@@ -95,8 +95,8 @@ ERC725Y JSON Schema `ERC725Account`:
         "name": "LSP1UniversalReceiverDelegate",
         "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
         "keyType": "Singleton",
-        "valueContent": "Address",
-        "valueType": "address"
+        "valueType": "address",
+        "valueContent": "Address"
     }
 ]
 ```

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -70,7 +70,7 @@ A simple key is constructed using `bytes32(keccak256(KeyName))`,
 
 Below is an example of a Singleton key type:
 
-```js
+```json
 {
     "name": "MyKeyName",
     "key": "0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2",
@@ -142,7 +142,7 @@ A mapping key is constructed using `bytes16(keccak256(FirstWord)) + bytes12(0) +
 
 Below is an example of a mapping key type:
 
-```js
+```json
 {
     "name": "SupportedStandards:ERC725Account",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
@@ -161,7 +161,7 @@ e.g. `MyCoolAddress:<address>` > `0x22496f48a493035f 00000000 cafecafecafecafeca
 
 Below is an example of an bytes20 mapping key type:
 
-```js
+```json
 {
     "name": "MyCoolAddress:cafecafecafecafecafecafecafecafecafecafe",
     "key": "0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe",
@@ -180,7 +180,7 @@ e.g. `AddressPermissions:Permissions:<address>` > `0x4b80742d 00000000 eced 0000
 
 Below is an example of a mapping key type:
 
-```js
+```json
 {
     "name": "AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe",
     "key": "0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe",

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -75,8 +75,8 @@ Below is an example of a Singleton key type:
     "name": "MyKeyName",
     "key": "0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2",
     "keyType": "Singleton",
-    "valueType": mixed,
-    "valueContent": mixed
+    "valueType": "Mixed",
+    "valueContent": "Mixed"
 }
 ```
 
@@ -147,8 +147,8 @@ Below is an example of a mapping key type:
     "name": "SupportedStandards:ERC725Account",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
     "keyType": "Mapping",
-    "valueType": mixed,
-    "valueContent": mixed
+    "valueType": "Mixed",
+    "valueContent": "Mixed"
 }
 ```
 
@@ -166,8 +166,8 @@ Below is an example of an bytes20 mapping key type:
     "name": "MyCoolAddress:cafecafecafecafecafecafecafecafecafecafe",
     "key": "0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "Bytes20Mapping",
-    "valueType": mixed,
-    "valueContent": mixed
+    "valueType": "Mixed",
+    "valueContent": "Mixed"
 }
 ```
 
@@ -185,8 +185,8 @@ Below is an example of a mapping key type:
     "name": "AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe",
     "key": "0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueType": mixed,
-    "valueContent": mixed
+    "valueType": "Mixed",
+    "valueContent": "Mixed"
 }
 ```
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -75,8 +75,8 @@ Below is an example of a Singleton key type:
     "name": "MyKeyName",
     "key": "0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2",
     "keyType": "Singleton",
-    "valueContent": mixed,
-    "valueType": mixed
+    "valueType": mixed,
+    "valueContent": mixed
 }
 ```
 
@@ -114,8 +114,8 @@ Below is an example of an Array key type:
     "name": "LSP3IssuedAssets[]",
     "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
     "keyType": "Array",
-    "valueContent": "Address", // describes the content of the elements
-    "valueType": "address" // describes the content of the elements
+    "valueType": "address", // describes the content of the elements
+    "valueContent": "Address" // describes the content of the elements
 }
 ```
 
@@ -147,8 +147,8 @@ Below is an example of a mapping key type:
     "name": "SupportedStandards:ERC725Account",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
     "keyType": "Mapping",
-    "valueContent": mixed,
-    "valueType": mixed
+    "valueType": mixed,
+    "valueContent": mixed
 }
 ```
 
@@ -166,8 +166,8 @@ Below is an example of an bytes20 mapping key type:
     "name": "MyCoolAddress:cafecafecafecafecafecafecafecafecafecafe",
     "key": "0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "Bytes20Mapping",
-    "valueContent": mixed,
-    "valueType": mixed
+    "valueType": mixed,
+    "valueContent": mixed
 }
 ```
 
@@ -185,8 +185,8 @@ Below is an example of a mapping key type:
     "name": "AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe",
     "key": "0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": mixed,
-    "valueType": mixed
+    "valueType": mixed,
+    "valueContent": mixed
 }
 ```
 
@@ -328,22 +328,22 @@ To allow interfaces to auto decode an ERC725Y key value store using the ERC725Y 
         "name": "SupportedStandards:ERC725Account",
         "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
         "keyType": "Mapping",
-        "valueContent": "0xafdeb5d6",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "0xafdeb5d6"
     },
     {
         "name": "LSP3Profile",
         "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
         "keyType": "Singleton",
-        "valueContent": "JSONURL",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "JSONURL"
     },
     {
         "name": "LSP3IssuedAssets[]",
         "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
         "keyType": "Array",
-        "valueContent": "Address",
         "valueType": "address",
+        "valueContent": "Address"
     }
 ]
 ```

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -38,8 +38,8 @@ The supported standard SHOULD be `LSP3UniversalProfile`
     "name": "SupportedStandards:LSP3UniversalProfile",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
     "keyType": "Mapping",
-    "valueContent": "0xabe425d6",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "0xabe425d6"
 }
 ```
 
@@ -53,8 +53,8 @@ A JSON file that describes the profile information, including profile image, bac
     "name": "LSP3Profile",
     "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
     "keyType": "Singleton",
-    "valueContent": "JSONURL",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "JSONURL"
 }
 ```
 
@@ -177,8 +177,8 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
     "name": "LSP3IssuedAssetsMap:<address>",
     "key": "0x83f5e77bfb14241600000000<address>",
     "keyType": "Mapping",
-    "valueContent": "Mixed",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "Mixed"
 }
 ```
 
@@ -202,29 +202,29 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
         "name": "SupportedStandards:LSP3UniversalProfile",
         "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
         "keyType": "Mapping",
-        "valueContent": "0xabe425d6",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "0xabe425d6"
     },
     {
         "name": "LSP3Profile",
         "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
         "keyType": "Singleton",
-        "valueContent": "JSONURL",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "JSONURL"
     },
     {
         "name": "LSP3IssuedAssetsMap:<address>",
         "key": "0x83f5e77bfb14241600000000<address>",
         "keyType": "Mapping",
-        "valueContent": "Mixed",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "Mixed"
     },
     {
         "name": "LSP3IssuedAssets[]",
         "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
         "keyType": "Array",
-        "valueContent": "Address",
-        "valueType": "address"
+        "valueType": "address",
+        "valueContent": "Address"
     },
 
     // from LSP5 ReceivedAssets
@@ -232,15 +232,15 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
         "name": "LSP5ReceivedAssetsMap:<address>",
         "key": "0x812c4334633eb81600000000<address>",
         "keyType": "Mapping",
-        "valueContent": "Mixed",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "Mixed"
     },
     {
         "name": "LSP5ReceivedAssets[]",
         "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
         "keyType": "Array",
-        "valueContent": "Address",
-        "valueType": "address"
+        "valueType": "address",
+        "valueContent": "Address"
     },
 
     // from ERC725Account
@@ -248,8 +248,8 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
         "name": "LSP1UniversalReceiverDelegate",
         "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
         "keyType": "Singleton",
-        "valueContent": "Address",
-        "valueType": "address"
+        "valueType": "address",
+        "valueContent": "Address"
     }
 ]
 ```

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -173,8 +173,6 @@ An array of ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines t
     "keyType": "Array",
     "valueContent": "Number",
     "valueType": "uint256",
-    "elementValueContent": "Address",
-    "elementValueType": "address"
 }
 ```
 
@@ -253,8 +251,6 @@ ERC725Y JSON Schema `LSP4DigitalAsset`:
         "keyType": "Array",
         "valueContent": "Number",
         "valueType": "uint256",
-        "elementValueContent": "Address",
-        "elementValueType": "address"
     }
 ]
 ```

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -39,8 +39,8 @@ The supported standard SHOULD be `LSP4DigitalAsset`
     "name": "SupportedStandards:LSP4DigitalAsset",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
     "keyType": "Mapping",
-    "valueContent": "0xa4d96624",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "0xa4d96624"
 }
 ```
 
@@ -53,8 +53,8 @@ A string representing the name for the token collection.
       "name": "LSP4TokenName",
       "key": "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
       "keyType": "Singleton",
-      "valueContent": "String",
-      "valueType": "string"
+      "valueType": "string",
+      "valueContent": "String"
   }
 ```
 
@@ -69,8 +69,8 @@ A string representing the symbol for the token collection. Symbols should be UPP
       "name": "LSP4TokenSymbol",
       "key": "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
       "keyType": "Singleton",
-      "valueContent": "String",
-      "valueType": "string"
+      "valueType": "string",
+      "valueContent": "String"
   }
 ```
 
@@ -86,8 +86,8 @@ The description of the asset.
     "name": "LSP4Metadata",
     "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
     "keyType": "Singleton",
-    "valueContent": "JSONURL",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "JSONURL"
 }
 ```
 
@@ -171,8 +171,8 @@ An array of ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines t
     "name": "LSP4Creators[]",
     "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
     "keyType": "Array",
-    "valueContent": "Number",
     "valueType": "uint256",
+    "valueContent": "Number"
 }
 ```
 
@@ -192,8 +192,8 @@ Where:
     "name": "LSP4CreatorsMap:<address>",
     "key": "0x6de85eaf5d982b4e00000000<address>",
     "keyType": "Mapping",
-    "valueContent": "Mixed",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "Mixed"
 }
 ```
 
@@ -214,43 +214,43 @@ ERC725Y JSON Schema `LSP4DigitalAsset`:
         "name": "SupportedStandards:LSP4DigitalAsset",
         "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
         "keyType": "Mapping",
-        "valueContent": "0xa4d96624",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "0xa4d96624"
     },
     {
         "name": "LSP4TokenName",
         "key": "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
         "keyType": "Singleton",
-        "valueContent": "String",
-        "valueType": "string"
+        "valueType": "string",
+        "valueContent": "String"
     },
     {
         "name": "LSP4TokenSymbol",
         "key": "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
         "keyType": "Singleton",
-        "valueContent": "String",
-        "valueType": "string"
+        "valueType": "string",
+        "valueContent": "String"
     }
     {
         "name": "LSP4Metadata",
         "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
         "keyType": "Singleton",
-        "valueContent": "JSONURL",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "JSONURL"
     },
     {
         "name": "LSP4CreatorsMap:<address>",
         "key": "0x6de85eaf5d982b4e00000000<address>",
         "keyType": "Mapping",
-        "valueContent": "Mixed",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "Mixed"
     },
     {
         "name": "LSP4Creators[]",
         "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
         "keyType": "Array",
-        "valueContent": "Number",
         "valueType": "uint256",
+        "valueContent": "Number"
     }
 ]
 ```

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -43,8 +43,8 @@ An array of received smart contract assets, like tokens (_e.g.: [LSP7 Digital As
     "name": "LSP5ReceivedAssets[]",
     "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
     "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
 }
 ```
 
@@ -63,8 +63,8 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
     "name": "LSP5ReceivedAssetsMap:<address>",
     "key": "0x812c4334633eb81600000000<address>",
     "keyType": "Mapping",
-    "valueContent": "Mixed",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "Mixed"
 }
 ```
 
@@ -81,15 +81,15 @@ ERC725Y JSON Schema `LSP5ReceivedAssets`:
         "name": "LSP5ReceivedAssetsMap:<address>",
         "key": "0x812c4334633eb81600000000<address>",
         "keyType": "Mapping",
-        "valueContent": "Mixed",
-        "valueType": "bytes"
+        "valueType": "bytes",
+        "valueContent": "Mixed"
     },
     {
         "name": "LSP5ReceivedAssets[]",
         "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
         "keyType": "Array",
-        "valueContent": "Address",
-        "valueType": "address"
+        "valueType": "address",
+        "valueContent": "Address"
     }
 ]
 ```

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -60,8 +60,8 @@ This is mainly useful for interfaces to know which address hold permissions.
     "name": "AddressPermissions[]",
     "key": "0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3",
     "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
 }
 ```
 
@@ -76,8 +76,8 @@ Contains [the permissions](#permission-values-in-addresspermissionspermissionsad
     "name": "AddressPermissions:Permissions:<address>",
     "key": "0x4b80742d0000000082ac0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": "BitArray",
-    "valueType": "byte32"
+    "valueType": "byte32",
+    "valueContent": "BitArray"
 }
 ```
     
@@ -91,8 +91,8 @@ IF no addresses are set, interacting with ALL addresses is allowed. IF one or mo
     "name": "AddressPermissions:AllowedAddresses:<address>",
     "key": "0x4b80742d00000000c6dd0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": "Address",
-    "valueType": "address[]"
+    "valueType": "address[]",
+    "valueContent": "Address"
 }
 ```
 
@@ -105,8 +105,8 @@ Contains an array of bytes4 function signatures, the controlling address is allo
     "name": "AddressPermissions:AllowedFunctions:<address>",
     "key": "0x4b80742d000000008efe0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": "Bytes4",
-    "valueType": "bytes4[]"
+    "valueType": "bytes4[]",
+    "valueContent": "Bytes4"
 }
 ```
 
@@ -119,8 +119,8 @@ Contains an array of bytes4 [ERC165 interface Ids](https://eips.ethereum.org/EIP
     "name": "AddressPermissions:AllowedStandards:<address>",
     "key": "0x4b80742d000000003efa0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": "Bytes4",
-    "valueType": "bytes4[]"
+    "valueType": "bytes4[]",
+    "valueContent": "Bytes4"
 }
 ```
 
@@ -311,36 +311,36 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
         "name": "AddressPermissions[]",
         "key": "0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3",
         "keyType": "Array",
-        "valueContent": "Address",
-        "valueType": "address"
+        "valueType": "address",
+        "valueContent": "Address"
     },
     {
         "name": "AddressPermissions:Permissions:<address>",
         "key": "0x4b80742d0000000082ac0000<address>",
         "keyType": "Bytes20MappingWithGrouping",
-        "valueContent": "BitArray",
-        "valueType": "byte32"
+        "valueType": "byte32",
+        "valueContent": "BitArray"
     },
     {
         "name": "AddressPermissions:AllowedAddresses:<address>",
         "key": "0x4b80742d00000000c6dd0000<address>",
         "keyType": "Bytes20MappingWithGrouping",
-        "valueContent": "Address",
-        "valueType": "address[]"
+        "valueType": "address[]",
+        "valueContent": "Address"
     },
     {
         "name": "AddressPermissions:AllowedFunctions:<address>",
         "key": "0x4b80742d000000008efe0000<address>",
         "keyType": "Bytes20MappingWithGrouping",
-        "valueContent": "Bytes4",
-        "valueType": "bytes4[]"
+        "valueType": "bytes4[]",
+        "valueContent": "Bytes4"
     },
     {
         "name": "AddressPermissions:AllowedStandards:<address>",
         "key": "0x4b80742d000000003efa0000<address>",
         "keyType": "Bytes20MappingWithGrouping",
-        "valueContent": "Bytes4",
-        "valueType": "bytes4[]"
+        "valueType": "bytes4[]",
+        "valueContent": "Bytes4"
     }
 ]
 ```

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -76,7 +76,7 @@ Contains [the permissions](#permission-values-in-addresspermissionspermissionsad
     "name": "AddressPermissions:Permissions:<address>",
     "key": "0x4b80742d0000000082ac0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueType": "byte32",
+    "valueType": "bytes32",
     "valueContent": "BitArray"
 }
 ```
@@ -318,7 +318,7 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
         "name": "AddressPermissions:Permissions:<address>",
         "key": "0x4b80742d0000000082ac0000<address>",
         "keyType": "Bytes20MappingWithGrouping",
-        "valueType": "byte32",
+        "valueType": "bytes32",
         "valueContent": "BitArray"
     },
     {

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -54,8 +54,8 @@ Expected values are represented by the enum:
     "name": "LSP8TokenIdType",
     "key": "0x715f248956de7ce65e94d9d836bfead479f7e70d69b718d47bfe7b00e05b4fe4",
     "keyType": "Singleton",
-    "valueContent": "Number",
-    "valueType": "uint256"
+    "valueType": "uint256",
+    "valueContent": "Number"
 }
 ```
 
@@ -70,8 +70,8 @@ When a metadata contract is created for a tokenId, the address COULD be stored i
     "name": "LSP8MetadataAddress:0x20BytesTokenIdHash",
     "key": "0x73dcc7c3c4096cdc00000000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "Bytes20Mapping",
-    "valueContent": Mixed,
-    "valueType": mixed
+    "valueType": mixed,
+    "valueContent": Mixed
 }
 ```
 
@@ -86,8 +86,8 @@ When metadata JSON is created for a tokenId, the URL COULD be stored in the mint
     "name": "LSP8MetadataJSON:0x20BytesTokenIdHash",
     "key": "0x9a26b4060ae7f7d500000000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "Bytes20Mapping",
-    "valueContent": JSONURL,
-    "valueType": bytes
+    "valueType": bytes,
+    "valueContent": JSONURL
 }
 ```
 For construction of the Bytes20Mapping key see: [LSP2 ERC725Y JSON Schema][LSP2#bytes20mapping]
@@ -107,8 +107,8 @@ The `address` of the contract which minted this tokenId, to be stored in the [ER
     "name": "LSP8TokenIdMetadata:MintedBy",
     "key": "0xa0093ef0f6788cc87a372bbd12cf83ae7eeb2c85b87e43517ffd5b3978d356c9",
     "keyType": "Singleton",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
 }
 ```
 
@@ -121,8 +121,8 @@ The `bytes32` of the `tokenId` this metadata is for, to be stored in the [ERC725
     "name": "LSP8TokenIdMetadata:TokenId",
     "key": "0x51ea539c2c3a29af57cb4b60be9d43689bfa633dba8613743d1be7fb038d36c3",
     "keyType": "Singleton",
-    "valueContent": "Bytes32",
-    "valueType": "bytes32"
+    "valueType": "bytes32",
+    "valueContent": "Bytes32"
 }
 ```
 
@@ -141,8 +141,8 @@ The description of the asset.
     "name": "LSP4Metadata",
     "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
     "keyType": "Singleton",
-    "valueContent": "JSONURL",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "JSONURL"
 }
 ```
 

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -70,8 +70,8 @@ When a metadata contract is created for a tokenId, the address COULD be stored i
     "name": "LSP8MetadataAddress:0x20BytesTokenIdHash",
     "key": "0x73dcc7c3c4096cdc00000000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "Bytes20Mapping",
-    "valueType": mixed,
-    "valueContent": Mixed
+    "valueType": "Mixed",
+    "valueContent": "Mixed"
 }
 ```
 

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -86,8 +86,8 @@ When metadata JSON is created for a tokenId, the URL COULD be stored in the mint
     "name": "LSP8MetadataJSON:0x20BytesTokenIdHash",
     "key": "0x9a26b4060ae7f7d500000000cafecafecafecafecafecafecafecafecafecafe",
     "keyType": "Bytes20Mapping",
-    "valueType": bytes,
-    "valueContent": JSONURL
+    "valueType": "bytes",
+    "valueContent": "JSONURL"
 }
 ```
 For construction of the Bytes20Mapping key see: [LSP2 ERC725Y JSON Schema][LSP2#bytes20mapping]


### PR DESCRIPTION
# What does this PR introduce?

Improvement and fixes for ERC725Y keys descriptions and JSON schemas (snippets).

- [x] removed deprecated `elementValueType` and `elementValueContent` in LSP4

Organised layout of each ERC725Y JSON schema across LSPs

- **improve readability** by putting `valueType` first, `valueContent` second

For other fixes, see commit titles below