### PR TITLE
refactor: use `bytes4` for `SupportedStandards` key

### DIFF
--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -328,7 +328,7 @@ To allow interfaces to auto decode an ERC725Y key value store using the ERC725Y 
         "name": "SupportedStandards:ERC725Account",
         "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
         "keyType": "Mapping",
-        "valueType": "bytes",
+        "valueType": "bytes4",
         "valueContent": "0xafdeb5d6"
     },
     {

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -38,7 +38,7 @@ The supported standard SHOULD be `LSP3UniversalProfile`
     "name": "SupportedStandards:LSP3UniversalProfile",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
     "keyType": "Mapping",
-    "valueType": "bytes",
+    "valueType": "bytes4",
     "valueContent": "0xabe425d6"
 }
 ```
@@ -202,7 +202,7 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
         "name": "SupportedStandards:LSP3UniversalProfile",
         "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
         "keyType": "Mapping",
-        "valueType": "bytes",
+        "valueType": "bytes4",
         "valueContent": "0xabe425d6"
     },
     {

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -39,7 +39,7 @@ The supported standard SHOULD be `LSP4DigitalAsset`
     "name": "SupportedStandards:LSP4DigitalAsset",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
     "keyType": "Mapping",
-    "valueType": "bytes",
+    "valueType": "bytes4",
     "valueContent": "0xa4d96624"
 }
 ```
@@ -214,7 +214,7 @@ ERC725Y JSON Schema `LSP4DigitalAsset`:
         "name": "SupportedStandards:LSP4DigitalAsset",
         "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
         "keyType": "Mapping",
-        "valueType": "bytes",
+        "valueType": "bytes4",
         "valueContent": "0xa4d96624"
     },
     {


### PR DESCRIPTION
# What does this PR introduce?

The ERC725Y keys `SupportedStandards:{StandardName}` are defined with `bytes` as their `valueType`

However, these keys all use a `bytes4` literal as a value `valueContent`

Change the LSP Metadata specs that use these key by specifying `bytes4`  as `valueType`