### PR TITLE
refactor: improve LSP2 specs

### DIFF
--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -53,66 +53,13 @@ To make ERC725Y keys readable, we describe a key-value pair as a JSON object con
 
 The table below describes each entries with their available options. 
 
-<table style="text-align: center">
-    <thead>
-        <tr>
-            <th style="text-align: center"><a href="#name"><code>name</code></th>
-            <th style="text-align: center"><a href="#key"><code>key</code></th>
-            <th style="text-align: center"><a href="#keyType"><code>keyType</code></th>
-            <th style="text-align: center"><a href="#valueType"><code>valueType</code></th>
-            <th style="text-align: center"><a href="#valueContent"><code>valueContent</code></th>
-        </tr>
-    </thead>
-    <tbody align="center">
-        <tr>
-            <td>the name of the key</td>
-            <td>the <b>unique identifier</b> of the key</td>
-            <td>
-                <i>How</i> the key MUST be <b>treated</b>
-                <hr>
-                <p><a href="#singleton"><code>Singleton</code></a></p>
-                <p><a href="#array"><code>Array</code></a></p>
-                <p><a href="#mapping"><code>Mapping</code></a></p>
-                <p><a href="#bytes20mapping"><code>Bytes20Mapping</code></a></p>
-                <p><a href="#bytes20mappingwithgrouping"><code>Bytes20MappingWithGrouping</code></a></p>
-            </td>
-            <td align="center">
-                <i>How</i> a value MUST be <b>decoded</b>
-                <hr>
-                <p><code>boolean</code></p>
-                <p><code>string</code></p>
-                <p><code>address</code></p>
-                <p><code>uintN</code></p>
-                <p><code>intN</code></p>
-                <p><code>bytesN</code></p>
-                <p><code>bytes</code></p>
-                <p><code>uintN[]</code></p>
-                <p><code>intN[]</code></p>
-                <p><code>string[]</code></p>
-                <p><code>address[]</code></p>
-                <p><code>bytes[]</code></p>
-            </td>
-            <td style="text-align: center">
-                <i>How</i> a value SHOULD be <b>interpreted</b>
-                <hr>
-                <p><code>Boolean</code></p>
-                <p><code>String</code></p>
-                <p><code>Address</code></p>
-                <p><code>Number</code></p>
-                <p><code>BytesN</code></p>
-                <p><code>Bytes</code></p>
-                <p><code>Keccak256</code></p>
-                <p><a href="#bitarray"><code>BitArray</code></a></p>
-                <p><code>URL</code></p>
-                <p><a href="#asseturl"><code>AssetURL</code></a></p>
-                <p><a href="#jsonurl"><code>JSONURL</code></a></p>
-                <p><code>Markdown</code></p>
-                <p><code>Literal</code><br/> (<u>e.g.:</u> <code>0x1345ABCD...</code>)</p>
-            </td>
-        </tr>
-    </tbody>
-</table>
-
+| Title | Description |
+|:-----|:-----|
+|[`name`](#name)| the name of the key |
+|[`key`](#key)| the **unique identifier** of the key |
+|[`keyType`](#keyType)| *How* the key must be treated <hr> [`Singleton`](#Singleton) <br> [`Array`](#Array) <br> [`Mapping`](#Mapping) <br> [`Bytes20Mapping`](#Bytes20Mapping) <br> [`Bytes20MappingWithGrouping`](#Bytes20MappingWithGrouping) |
+|[`valueType`](#valueType)| *How* a value MUST be decoded <hr> `boolean` <br> `string` <br> `address` <br> `uintN` <br> `intN` <br> `bytesN` <br> `bytes` <br> `uintN[]` <br> `intN[]` <br> `string[]` <br> `address[]` <br> `bytes[]` |
+|[`valueContent`](#valueContent)| *How* a value SHOULD be interpreted <hr> `Boolean` <br> `String` <br> `Address` <br> `Number` <br> `BytesN` <br> `Bytes` <br> `Keccak256` <br> [`BitArray`](#BitArray) <br> `URL` <br> [`AssetURL`](#AssetURL) <br> [`JSONURL`](#JSONURL) <br> `Markdown` <br> `Literal` (*e.g.:* `0x1345ABCD...`) |
 
 ### `name`
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -58,7 +58,7 @@ The table below describes each entries with their available options.
     <tbody align="center">
         <tr>
             <td>the name of the key</td>
-            <td>the <code>keccak256</code> hash of the <code>name</code></td>
+            <td>the <b>unique identifier</b> of the key</td>
             <td>
                 <i>How</i> the key MUST be <b>treated</b>
                 <hr>
@@ -123,7 +123,14 @@ In scenarios where an ERC725Y key is part of an LSP Standard (Metadata standard)
 
 The `key` is a `bytes32` value that acts as **unique identifier** for the key. It is the actual key that MUST be used to retrieve the value stored in the contract storage, via `ERC725Y.getData(bytes32 key)`.
 
-*e.g.:* `keccak256('LSP2Name') = 0xf9e26448acc9f20625c059a95279675b8f58ba4f06d262f83a32b4dd35dee019`
+The standard `keccak256` hashing algorithm is used to generate this identifier. However, *how* the identifier is constructed varies, depending on the `keyType`:
+
+- for `Singleton` keys: the hash of the key name (*e.g.:* `keccak256('MyKeyName') = 0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2`)
+- for `Array` keys (see [`Array`](#array) section for more details)
+  - an initial key containing the array length.
+  - subsequent keys for array index access.
+- for mapping keys, see each mapping type seperately below.
+
 
 ### `keyType`
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -12,15 +12,15 @@ requires: ERC725Y
 
 ## Simple Summary
 
-This schema defines how a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key-value pairs can be described. It can be used as an abstract structure over the storage of an ERC725Y smart contract.
+This schema defines how a single [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key-value pair can be described. It can be used as an abstract structure over the storage of an ERC725Y smart contract.
 
 ## Abstract
 
-ERC725Y enables storing any data in a smart contract as `bytes32` > `bytes` key-value pairs.
+ERC725Y enables storing any data in a smart contract as `bytes32 => bytes` key-value pairs.
 
-Although this improves the way to interact with the data stored, it remains difficult to understand the layout of the contract storage. This is because both the key and the value are addressed in raw bytes.
+Although this improves interaction with the data stored, it remains difficult to understand the layout of the contract storage. This is because both the key and the value are addressed in raw bytes.
 
-This schema allows to standardize those keys and values so that they can be more easily accessed and interpreted. It can be used to create ERC725Y sub-standards, made of pre-defined sets of ERC725Y keys (Metadata Standards).
+This schema allows to standardize those keys and values so that they can be more easily accessed and interpreted. It can be used to create ERC725Y sub-standards, made of pre-defined sets of ERC725Y keys.
 
 ## Motivation
 
@@ -28,16 +28,16 @@ A schema defines a blueprint for how a data store is constructed.
 
 In the context of smart contracts, it can offer a better view of how the data is organised and structured within the contract storage.
 
-Using a schema over ERC725Y enables those keys and values to be easily readable and automatically parsable. Contracts and interfaces can know how to read and interact with the storage of an ERC725Y smart contract.
+Using a standardised schema over ERC725Y enables those keys and values to be easily readable and automatically parsable. Contracts and interfaces can know how to read and interact with the storage of an ERC725Y smart contract.
 
-The benefit of such schema is to allow interfaces or smart contracts to better decode (read, parse and interpret) the data stored in an ERC725Y contract. On the other hand, it also enables interfaces and contracts to know how to correctly encode data, before being set on an ERC725Y contract.
+The advantage of such schema is to allow interfaces or smart contracts to better decode (read, parse and interpret) the data stored in an ERC725Y contract. It is less error-prone due to knowing data types upfront. On the other hand, it also enables interfaces and contracts to know how to correctly encode data, before being set on an ERC725Y contract.
 
 This schema is for example used in [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) based smart contracts like
 [LSP3-UniversalProfile](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-UniversalProfile-Metadata.md) and [LSP4-DigitalAsset-Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md).
 
 ## Specification
 
-> **Note:** this set might not yet be complete, as it could be extended overtime.
+> **Note:** described sets might not yet be complete, as they could be extended over time.
 
 To make ERC725Y keys readable, we describe a key-value pair as a JSON object containing the following entries:
 
@@ -65,13 +65,13 @@ The table below describes each entries with their available options.
 
 The `name` is the human-readable format of the ERC725Y key. It aims to abstract the representation of the ERC725Y key and defines what the key represents. In most cases, it SHOULD highlight the intent behind the key.
 
-In scenarios where an ERC725Y key is part of an LSP Standard (Metadata standard), the key `name` SHOULD be comprised of the following: `LSP{N}{KeyName}`, where
+In scenarios where an ERC725Y key is part of an LSP Standard, the key `name` SHOULD be comprised of the following: `LSP{N}{KeyName}`, where
 
 - `LSP`: abbreviation for **L**UKSO **S**tandards **P**roposal.
 - `N`: the **Standard Number** this key refers to.
-- `KeyName`: a short name for the ERC725Y key.
+- `KeyName`: base of the key name. Should represent the meaning of a value stored behind the key.
 
-*e.g.:* `MyColourTheme`, `LSP4TokenName`
+*e.g.:* `MyColourTheme` (not part of any LSP Standard), `LSP4TokenName` (part of a LSP standard)
 
 
 ### `key`

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -81,7 +81,7 @@ The `key` is a `bytes32` value that acts as the **unique identifier** for the ke
 The standard `keccak256` hashing algorithm is used to generate this identifier. However, *how* the identifier is constructed varies, depending on the `keyType`:
 
 - for `Singleton` keys: the hash of the key name (*e.g.:* `keccak256('MyKeyName') = 0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2`)
-- for `Array` keys (see [`Array`](#array) section for more details)
+- for `Array` keys (see [`Array`](#array) section for more details), **a combination of:**
   - an initial key containing the array length.
   - subsequent keys for array index access.
 - for mapping keys, see each mapping type separately below.

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -146,17 +146,11 @@ The `keyType` determines how the value(s) should be interpreted.
 
 | `keyType` | Description  | Example |
 |---|---|---|
-| [`Singleton`](#singleton)  | A simple key  | e.g.: `bytes32(keccak256("MyKeyName"))`|
-| [`Array`](#array)  | an array spanning multiple ERC725Y keys  | e.g.: `bytes32(keccak256("MyKeyName[]"))`|
-| [`Mapping`](#mapping)  | a key that map two words  | e.g.: `bytes16(keccak256("MyKeyName"))` + `bytes12(0)` + `bytes4(keccak256("MapName"))`|
-| [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` | e.g.: `bytes8(keccak256("MyKeyName"))` + `bytes4(0)` +  `bytes20(dynamicValue)` |
-| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  | e.g.: `bytes4(keccak256("MyKeyName"))` + `bytes4(0)` + `bytes2(keccak256("MapName"))` + `bytes2(0)` +  `bytes20(dynamicValue)` |
-
-For the mapping key types (`Mapping`, `Bytes20Mapping` and `Bytes20MappingWithGrouping`), the term *"word"* COULD describe:
-- a single word (*e.g.: "SupportedStandards"*)
-- a random string, or sequence of characters (*e.g.: "RG58012-RO-120-Y"*)
-
-For the mapping key types, the *"word"* MUST NOT contain a ":" (colon character), as it is used for the delimiter between both words.
+| [`Singleton`](#singleton)  | A simple key  | `bytes32(keccak256("MyKeyName"))`<br> --- <br> `MyKeyName` -->  `0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2` |
+| [`Array`](#array)  | an array spanning multiple ERC725Y keys  | `bytes32(keccak256("MyKeyName[]"))` <br> --- <br> `MyKeyName[]` -->   `0x24f6297f3abd5a8b82f1a48cee167cdecef40aa98fbf14534ea3539f66ca834c`|
+| [`Mapping`](#mapping)  | a key that map two words  | `bytes16(keccak256("MyKeyName"))` + `bytes12(0)` + `bytes4(keccak256("MapName"))` <br> --- <br> `MyKeyName:MapName` -->  `0x24f6297f3abd5a8b82f1a48cee167cde000000000000000000000000e6041813` |
+| [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` | `bytes8(keccak256("MyKeyName"))` + `bytes4(0)` +  `bytes20(dynamicValue)` <br> --- <br> `MyKeyName:cafecafecafecafecafecafecafecafecafecafe` -->  `0x35e6950bc8d21a1600000000cafecafecafecafecafecafecafecafecafecafe` |
+| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  | `bytes4(keccak256("MyKeyName"))` + `bytes4(0)` + `bytes2(keccak256("MapName"))` + `bytes2(0)` +  `bytes20(dynamicValue)` <br> --- <br> `MyKeyName:MapName:cafecafecafecafecafecafecafecafecafecafe` -->  `0x35e6950b00000000e6040000cafecafecafecafecafecafecafecafecafecafe` |
 
 
 ### `valueType`

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -199,8 +199,8 @@ Below is an example of a mapping key type:
 
 ```json
 {
-    "name": "SupportedStandards:ERC725Account",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
+    "name": "SupportedStandards:LSP3UniversalProfile",
+    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
     "keyType": "Mapping",
     "valueType": "Mixed",
     "valueContent": "Mixed"
@@ -378,11 +378,11 @@ To allow interfaces to auto decode an ERC725Y key value store using the ERC725Y 
 ```json
 [
     {
-        "name": "SupportedStandards:ERC725Account",
-        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6",
+        "name": "SupportedStandards:LSP3UniversalProfile",
+        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
         "keyType": "Mapping",
         "valueType": "bytes4",
-        "valueContent": "0xafdeb5d6"
+        "valueContent": "0xabe425d6"
     },
     {
         "name": "LSP3Profile",

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -144,13 +144,13 @@ The standard `keccak256` hashing algorithm is used to generate this identifier. 
 
 The `keyType` determines how the value(s) should be interpreted.
 
-| `keyType` | Description  |
-|---|---|
-| [`Singleton`](#singleton)  | A simple key  |
-| [`Array`](#array)  | an array spanning multiple ERC725Y keys  |
-| [`Mapping`](#mapping)  | a key that map two words  |
-| [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` |
-| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  |
+| `keyType` | Description  | Example |
+|---|---|---|
+| [`Singleton`](#singleton)  | A simple key  | e.g.: `bytes32(keccak256("MyKeyName"))`|
+| [`Array`](#array)  | an array spanning multiple ERC725Y keys  | e.g.: `bytes32(keccak256("MyKeyName[]"))`|
+| [`Mapping`](#mapping)  | a key that map two words  | e.g.: `bytes16(keccak256("MyKeyName")) + `bytes12(0)` + bytes4(keccak256("MapName"))`|
+| [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` | e.g.: `bytes8(keccak256("MyKeyName")) + `bytes4(0)` +  `bytes20(dynamicValue)` |
+| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  | e.g.: `bytes4(keccak256("MyKeyName")) + `bytes4(0)` + bytes2(keccak256("MapName")) + `bytes2(0)` +  `bytes20(dynamicValue)` |
 
 For the mapping key types (`Mapping`, `Bytes20Mapping` and `Bytes20MappingWithGrouping`), the term *"word"* COULD describe:
 - a single word (*e.g.: "SupportedStandards"*)

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -29,42 +29,87 @@ This schema is for example used in [ERC725](https://github.com/ethereum/EIPs/blo
 
 ## Specification
 
-To make ERC725Y keys readable we define the following key value types:   
-(Note: this set is not complete yet, and should be extended over time)
+> **Note:** this set might not yet be complete, as it could be extended overtime.
 
-- `name`: Describes the name of the key, SHOULD compromise of the Standards name + sub type. e.g: `LSP2Name`
-- `key`: the keccak256 hash of the name. This is the actual key that MUST be retrievable via `ERC725Y.getData(bytes32 key)`. e.g: `keccack256('LSP2Name') = 0xf9e26448acc9f20625c059a95279675b8f58ba4f06d262f83a32b4dd35dee019`
-- `keyType`: Types that determine how the values should be interpreted. Valid types are:
-    - [`Singleton`](#singleton): A simple key.
-    - [`Array`](#array): An array spanning multiple ERC725Y keys.
-    - [`Mapping`](#mapping): A key that maps two words.
-    - [`Bytes20Mapping`](#bytes20mapping): A key that maps a word to an address.
-    - [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping): A key that maps a word, to a grouping word to an address.
-- `valueType`: The type the content MUST be decoded with.
-    - `string`: The bytes are a UTF8 encoded string
-    - `address`: The bytes are an 20 bytes address
-    - `uint256`: The bytes are a uint256
-    - `bytes32`: The bytes are a 32 bytes
-    - `bytes`: The bytes are a bytes
-    - `string[]`: The bytes are a UTF8 encoded string array
-    - `address[]`: The bytes are an 20 bytes address array
-    - `uint256[]`: The bytes are a uint256 array
-    - `bytes[]`: The bytes are a bytes array
-    - `bytesN[]`: The bytes are a N bytes
-- `valueContent`: The content in the returned value. Valid values are:
-    - `Bytes`: The content are bytes. 
-    - `BytesN`: The content are bytes with length N.
-    - `Number`: The content is a number.
-    - `String`: The content is a UTF8 string.
-    - `Address`: The content is an address.
-    - `Keccak256`: The content is an keccak256 32 bytes hash.
-    - [`AssetURL`](#asseturl): The content contains the hash function, hash and link to the asset file.
-    - [`JSONURL`](#jsonurl): The content contains the hash function, hash and link to the JSON file.
-    - `URL`: The content is an URL encoded as UTF8 string.
-    - `Markdown`: The content is structured Markdown mostly encoded as UTF8 string.
-    - `0x1345ABCD...`: If the value content are specific bytes, than the returned value is expected to equal those bytes.
-  
-### Singleton
+To make ERC725Y keys readable we define the following key value types:  
+
+- `name`: describes the name of the key.
+- `key`: the **keccak256** hash of the key `name`.
+- `keyType`
+- `valueType`
+- `valueContent`
+
+
+### `name`
+
+The key name SHOULD be comprised of the following: `LSP{N}{KeyName}`.
+
+- `LSP`: abbreviation for **L**UKSO **S**tandards **P**roposal.
+- `N`: the **Standard Number** this key refers to.
+- `KeyName`: the intent of the key.
+
+*e.g.:* `LSP4TokenName`
+
+
+### `key`
+
+This is the actual key that MUST be retrievable via `ERC725Y.getData(bytes32 key)`.
+
+*e.g.:* `keccack256('LSP2Name') = 0xf9e26448acc9f20625c059a95279675b8f58ba4f06d262f83a32b4dd35dee019`
+
+### `keyType`
+
+The `keyType` determines how the value(s) should be interpreted.
+
+|   |   |
+|---|---|
+| [`Singleton`](#singleton)  | A simple key  |
+| [`Array`](#array)  | an array spanning multiple ERC725Y keys  |
+| [`Mapping`](#mapping)  | a key that map two words  |
+| [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` |
+| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  |
+
+### `valueType`
+
+The type the content MUST be decoded with.
+
+|   |   |
+|---|---|
+| `boolean`  | a value as either **true** or **false** |
+| `string`  | an UTF8 encoded string  |
+| `address`  | a 20 bytes long address |
+| `uintN`  | an **unsigned** integer (= only positive number) of size `N`  |
+| `intN`  |a **signed** integer (= either positive or negative number) of size `N` |
+| `bytesN`  | a fixed-size bytes value of size `N` |
+| `bytes`  | a dynamically size bytes value, more than 32 bytes   |
+| `uintN[]`  | an array of **signed** integers |
+| `intN[]`  | an array of **unsigned** integers |
+| `string[]`  | an array of UTF8 encoded strings |
+| `address[]`  | an array of addresses   |
+| `bytes[]`   | an array of dynamic size bytes  |
+| `bytesN[]`  | an array of fixed size bytes  |
+
+### `valueContent`
+
+The content in the returned value. Valid values are:
+
+|   |   |
+|---|---|
+| `String`  | an UTF8 encoded string |
+| `Address`  | an address |
+| `Number`  | a Number (positive or negative, depending on the `keyType`)  |
+| `BytesN`  | a bytes of **fixed-size** `N`  |
+| `Bytes`  | a bytes |
+| `Keccak256`  | a 32 bytes long hash digest, obtained from the keccak256 hashing algorithm |
+| `BitArray`  | *TBD*  |
+| `URL`  | an URL encoded as UTF8 string  |
+| [`AssetURL`](#asseturl)  | The content contains the hash function, hash and link to the asset file  |
+| [`JSONURL`](#jsonurl)  |  hash function, hash and link to the JSON file |
+| `Markdown`  | a structured Markdown mostly encoded as UTF8 string  |
+| `0x1345ABCD...`  | a **literal** value, when the returned value is expected to equal some specific bytes |
+
+### Key Types explained
+#### Singleton
 
 A simple key is constructed using `bytes32(keccak256(KeyName))`,
 
@@ -80,7 +125,7 @@ Below is an example of a Singleton key type:
 }
 ```
 
-### Array
+#### Array
 
 An initial key of an array containing the array length constructed using `bytes32(keccak256(KeyName))`.
 Subsequent keys consist of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`.
@@ -119,7 +164,7 @@ Below is an example of an Array key type:
 }
 ```
 
-#### Example
+*example:*
 
 ```solidity
 key: keccak256('LSP3IssuedAssets[]') = 0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0
@@ -136,7 +181,7 @@ key: 0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001
 value: 0xcafecafecafecafecafecafecafecafecafecafe
 ```
 
-### Mapping
+#### Mapping
 
 A mapping key is constructed using `bytes16(keccak256(FirstWord)) + bytes12(0) + bytes4(keccak256(LastWord))`,    
 
@@ -152,7 +197,7 @@ Below is an example of a mapping key type:
 }
 ```
 
-### Bytes20Mapping
+#### Bytes20Mapping
 
 Bytes 20 mapping could be used to map words to addresses, or other bytes 20 long data.
 An bytes mapping key is constructed using `bytes8(keccak256(FirstWord)) + bytes4(0) + bytes20(address)`.
@@ -171,7 +216,7 @@ Below is an example of an bytes20 mapping key type:
 }
 ```
 
-### Bytes20MappingWithGrouping
+#### Bytes20MappingWithGrouping
 
 Bytes 20 mapping with grouping could be used to map two words to addresses, or other bytes 20 long data.
 A mapping key, constructed using `bytes4(keccak256(FirstWord)) + bytes4(0) + bytes2(keccak256(SecondWord)) + bytes2(0) + bytes20(address)`,     
@@ -190,7 +235,7 @@ Below is an example of a mapping key type:
 }
 ```
 
-### AssetURL
+#### AssetURL
 
 The content is bytes containing the following format:
 `bytes4(keccack256('hashFunction'))` + `bytes32(keccack256(assetBytes))` + `utf8ToHex('AssetURL')`
@@ -199,7 +244,7 @@ Known hash functions:
 
 - `0x8019f9b1`: keccak256('keccak256(bytes)')
 
-#### Example
+*example:*
 
 The following shows an example of how to encode an AssetURL:
 
@@ -237,7 +282,7 @@ keccak256(utf8)    hash                                                         
 0x8019f9b1d47cf10786205bb08ce508e91c424d413d0f6c48e24dbfde2920d16a9561a723697066733a2f2f516d57346e554e7933767476723344785a48754c66534c6e687a4b4d6532576d67735573454750504668385a7470
 ```
 
-### JSONURL
+#### JSONURL
 
 The content is bytes containing the following format:     
 `bytes4(keccack256('hashFunction'))` + `bytes32(keccack256(JSON.stringify(JSON)))` + `utf8ToHex('JSONURL')`
@@ -246,7 +291,7 @@ Known hash functions:
 
 - `0x6f357c6a`: keccak256('keccak256(utf8)')
 
-#### Example
+*example:*
 
 The following shows an example of how to encode a JSON object:
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -148,9 +148,9 @@ The `keyType` determines how the value(s) should be interpreted.
 |---|---|---|
 | [`Singleton`](#singleton)  | A simple key  | e.g.: `bytes32(keccak256("MyKeyName"))`|
 | [`Array`](#array)  | an array spanning multiple ERC725Y keys  | e.g.: `bytes32(keccak256("MyKeyName[]"))`|
-| [`Mapping`](#mapping)  | a key that map two words  | e.g.: `bytes16(keccak256("MyKeyName")) + `bytes12(0)` + bytes4(keccak256("MapName"))`|
+| [`Mapping`](#mapping)  | a key that map two words  | e.g.: `bytes16(keccak256("MyKeyName"))` + `bytes12(0)` + `bytes4(keccak256("MapName"))`|
 | [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` | e.g.: `bytes8(keccak256("MyKeyName")) + `bytes4(0)` +  `bytes20(dynamicValue)` |
-| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  | e.g.: `bytes4(keccak256("MyKeyName")) + `bytes4(0)` + bytes2(keccak256("MapName")) + `bytes2(0)` +  `bytes20(dynamicValue)` |
+| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  | e.g.: `bytes4(keccak256("MyKeyName"))` + `bytes4(0)` + `bytes2(keccak256("MapName"))` + `bytes2(0)` +  `bytes20(dynamicValue)` |
 
 For the mapping key types (`Mapping`, `Bytes20Mapping` and `Bytes20MappingWithGrouping`), the term *"word"* COULD describe:
 - a single word (*e.g.: "SupportedStandards"*)

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -202,9 +202,11 @@ Each Array element can be accessed through its own `key`. The `key` of an Array 
 
 Below is an example for the **Array** key named `LSP3IssuedAssets[]`.
 
-- element number: key: `0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0`, value: `0x0000000000000000000000000000000000000000000000000000000000000002` (2 elements)
-- element 1: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000`, value: `0x123...` (element 0)
-- element 2: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001`, value: `0x321...` (element 1)
+- total number of elements: 
+  - key: `0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0`, 
+  - value: `0x0000000000000000000000000000000000000000000000000000000000000002` (2 elements)
+- element 1: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000`, value: `0x123...` (index 0)
+- element 2: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001`, value: `0x321...` (index 1)
 ...
 
 ```json
@@ -223,11 +225,11 @@ value: uint256 (array length) e.g. 0x0000000000000000000000000000000000000000000
 
 // array items
 
-// element 0
+// 1st element (index 0)
 key: 0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000
 value: 0xcafecafecafecafecafecafecafecafecafecafe
 
-// element 1
+// 2nd element (index 1)
 key: 0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001
 value: 0xcafecafecafecafecafecafecafecafecafecafe
 ```

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -94,7 +94,7 @@ The table below describes each entries with their available options.
                 <p><code>BytesN</code></p>
                 <p><code>Bytes</code></p>
                 <p><code>Keccak256</code></p>
-                <p><code>BitArray</code></p>
+                <p><a href="#bitarray"><code>BitArray</code></a></p>
                 <p><code>URL</code></p>
                 <p><a href="#asseturl"><code>AssetURL</code></a></p>
                 <p><a href="#jsonurl"><code>JSONURL</code></a></p>
@@ -345,6 +345,14 @@ Below is an example of a mapping key type:
     "valueContent": "..."
 }
 ```
+
+### BitArray
+
+A BitArray describes an array that contains a sequence of bits (`1`s and `0`s).
+
+Each bit can be either set (`1`) or not (`0`). The point of the BitArray `valueContent` is that there are only two possible values, so they can be stored in one bit.
+
+A BitArray can be used as a mapping of values to states (on/off, allowed/disallowed, locked/unlocked, valid/invalid), where the max number of available values that can be mapped is *n* bits.
 
 ### AssetURL
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -31,13 +31,23 @@ This schema is for example used in [ERC725](https://github.com/ethereum/EIPs/blo
 
 > **Note:** this set might not yet be complete, as it could be extended overtime.
 
-To make ERC725Y keys readable we define the following key value types:  
+To make ERC725Y keys readable, we describe a key-value pair as a JSON object containing the following entries:
+
+```json
+{
+    "name": "...",
+    "key": "...",
+    "keyType": "...",
+    "valueType": "...",
+    "valueContent": "..."
+}
+```
 
 - `name`: describes the name of the key.
-- `key`: the **keccak256** hash of the key `name`.
-- `keyType`
-- `valueType`
-- `valueContent`
+- `key`: the **keccak256** hash of the `name`.
+- `keyType`: describe *how* the key MUST be treated.
+- `valueType`: describe *how* the value MUST be decoded.
+- `valueContent`: describe *how* a value SHOULD be treated.
 
 
 ### `name`
@@ -359,9 +369,7 @@ if(hashFunction === '0x6f357c6a') {
 
 ## Rationale
 
-The structure of the key value layout as JSON allows interfaces to auto decode these key values as they will know how to decode them.   
-`keyType` always describes *how* a key MUST be treated.    
-and `valueType` describes how the value MUST be decoded. And `value` always describes *how* a value SHOULD be treated.
+The structure of the key value layout as JSON allows interfaces to auto decode these key values as they will know how to decode them.
 
 ## Example
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -90,7 +90,9 @@ For the mapping key types, the *"word"* MUST NOT contain a ":" (colon character)
 
 ### `valueType`
 
-Describes the underlying data type of a value stored under a specific ERC725Y key. The `valueType` is relevant for interfaces to know how a value MUST be encoded / decoded. This include:
+Describes the underlying data type of a value stored under a specific ERC725Y key. It refers to the type for the smart contract language like [Solidity](https://docs.soliditylang.org).
+
+The `valueType` is relevant for interfaces to know how a value MUST be encoded / decoded. This include:
 
 - how to decode a value fetched via `ERC725Y.getData(...)`
 - how to encode a value that needs to be set via `ERC725Y.setData(...)`. 
@@ -159,16 +161,21 @@ Below is an example of a Singleton key type:
 
 #### Array
 
+An array of elements, where element has the same `valueType`.
+
+> *The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
+> Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit.*
+
+**Requirements**
+
+A key of **Array** type MUST follow the following requirements:
+
+- The `name` of the key MUST have a `[]` (square brackets).
+- The `key` itself MUST be the keccak256 hash digest of the **full key `name`, including the square brackets `[]`**
+- The key hash MUST contain the number of all elements, and is required to be updated when a new key element is added.
+
 An initial key of an array containing the array length constructed using `bytes32(keccak256(KeyName))`.
 Subsequent keys consist of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`.
-
-*The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
-Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit.*
-
-If you require multiple keys of the same key type they MUST be defined as follows:
-
-- The keytype name MUST have a `[]` add and then hashed
-- The key hash MUST contain the number of all elements, and is required to be updated when a new key element is added.
 
 For all other elements:
 
@@ -230,9 +237,8 @@ A **Mapping** key is constructed using `bytes16(keccak256("FirstWord")) + bytes1
 ```
 
 
-- `keccak256("FirstWord")` = `0x`**`f49648de3734d6c5458244ad87c893b5`**`0e6367d2cfa4670eddec109d1fc952e0` (**first 16 bytes** of the hash)
-- `keccak256("SecondWord")` = `0x`**`53022d37`**`21822ca6332135de9e7b98f9a82eb1051d3095d2e259b45149c9b634` (**first 4 bytes** of the hash)
-
+- `keccak256("FirstWord")` = `0x`<mark>`f49648de3734d6c5458244ad87c893b5`</mark>`0e6367d2cfa4670eddec109d1fc952e0` (**first 16 bytes** of the hash)
+- `keccak256("SecondWord")` = `0x`<mark>`53022d37`</mark>`21822ca6332135de9e7b98f9a82eb1051d3095d2e259b45149c9b634` (**first 4 bytes** of the hash)
 #### Bytes20Mapping
 
 **Bytes20Mapping** could be used to map words to `bytes20` long data, such as `addresses`. Such key type can be useful when the second word in the mapping is too long and makes the key greater than 32 bytes.

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -54,7 +54,7 @@ To make ERC725Y keys readable, we describe a key-value pair as a JSON object con
 The table below describes each entries with their available options. 
 
 | Title | Description |
-|:-----|:-----|
+|::----:-|::----:-|
 |[`name`](#name)| the name of the key |
 |[`key`](#key)| the **unique identifier** of the key |
 |[`keyType`](#keyType)| *How* the key must be treated <hr> [`Singleton`](#Singleton) <br> [`Array`](#Array) <br> [`Mapping`](#Mapping) <br> [`Bytes20Mapping`](#Bytes20Mapping) <br> [`Bytes20MappingWithGrouping`](#Bytes20MappingWithGrouping) |
@@ -298,24 +298,56 @@ Each bit can be either set (`1`) or not (`0`). The point of the BitArray `valueC
 
 A BitArray can be used as a mapping of values to states (on/off, allowed/disallowed, locked/unlocked, valid/invalid), where the max number of available values that can be mapped is *n* bits.
 
-Below is an example of a mapping key type:
+*example:*
+
+The example shows how a `BitArray` value can be read and interpreted.
 
 ```json
 {
     "name": "MyPermissions",
     "key": "0xaacedf1d8b2cc85524a881760315208fb03c6c26538760922d6b9dee915fd66a",
     "keyType": "Singleton",
-    "valueType": "bytes32",
+    "valueType": "bytes1",
     "valueContent": "BitArray"
 }
+```
 
-> Permissions set to 0010
-`0x000000000000000000000a`
+As the key `name` suggests, it defines a list of (user-defined) permissions, where each permission maps to a single bit at position `n`.
+- When a bit at position `n` is set (`1`), the permission defined at position `n` will be set.
+- When a bit at position `n` is not set (`0`), the permission defined at position `n` will not be set.
 
-> Permissions set to 0110
-`0x000000000000000000000a`
+Since the `valueType` is of type `bytes1`, this key can hold 8 user-defined permissions.
+
+For instance, for the following permissions:
+
+| `SIGN` | `TRANSFER VALUE` | `DEPLOY` | `DELEGATE CALL` | `STATIC CALL` | `CALL` | `SET DATA` | `CHANGE OWNER` |
+|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
+| `0` / `1` | `0` / `1` | `0` / `1` | `0` / `1` | `0` / `1` | `0` / `1` | `0` / `1` | `0` / `1` |
+
+Setting only the permission `SET DATA` will result in the following `bytes1` value (and its binary representation)
 
 ```
+> Permission SET DATA = permissions set to 0000 0010
+`0x02` (4 in decimal)
+```
+
+| `SIGN` | `TRANSFER VALUE` | `DEPLOY` | `DELEGATE CALL` | `STATIC CALL` | `CALL` | `SET DATA` | `CHANGE OWNER` |
+|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
+| `0` | `0` | `0` | `0` | `0` | `0` | `1` | `0` |
+
+Setting multiple permissions like `TRANSFER VALUE + CALL + SET DATA` will result in the following `bytes1` value (and its binary representation)
+
+```
+> Permissions set to 0100 0110
+`0x46` (70 in decimal)
+
+```
+
+| `SIGN` | `TRANSFER VALUE` | `DEPLOY` | `DELEGATE CALL` | `STATIC CALL` | `CALL` | `SET DATA` | `CHANGE OWNER` |
+|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
+| `0` | `1` | `0` | `0` | `0` | `1` | `1` | `0` |
+
+The idea is to always read the value of a **BitArray** key as binary digits, while its content is always written as a `bytes1` (in hex) in the ERC725Y contract storage.
 
 ### AssetURL
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -81,10 +81,16 @@ The `keyType` determines how the value(s) should be interpreted.
 | [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` |
 | [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  |
 
-> **Note:** for the Mapping key types, the words MUST NOT contain ":" (colon character), as it is used for the delimiter between both words.
+For the mapping key types (`Mapping`, `Bytes20Mapping` and `Bytes20MappingWithGrouping`), the term *"word"* COULD describe:
+- a single word (*e.g.: "SupportedStandards"*)
+- a random string, or sequence of characters (*e.g.: "RG58012-RO-120-Y"*)
+
+For the mapping key types, the *"word"* MUST NOT contain a ":" (colon character), as it is used for the delimiter between both words.
+
+
 ### `valueType`
 
-Describes the underlying type for a value stored under a specific ERC725Y key. The `valueType` is relevant for interfaces to know how a value MUST be encoded / decoded. This include:
+Describes the underlying data type of a value stored under a specific ERC725Y key. The `valueType` is relevant for interfaces to know how a value MUST be encoded / decoded. This include:
 
 - how to decode a value fetched via `ERC725Y.getData(...)`
 - how to encode a value that needs to be set via `ERC725Y.setData(...)`. 
@@ -109,7 +115,13 @@ The `valueType` can also be useful for type casting. It enables contracts or int
 
 ### `valueContent`
 
-The content in the returned value. Valid values are:
+Describes how to interpret the content of the returned value.
+
+To illustrate, a string could be interpreted in multiple ways, such as:
+- a single word, or a sequence of words (*e.g.: "My Custom Token Name"*)
+- an URL (*e.g.: "ipfs://QmW4nUNy3vtvr3DxZHuLfSLnhzKMe2WmgsUsEGPPFh8Ztp"*)
+
+Valid `valueContent` are:
 
 |   |   |
 |---|---|

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -12,20 +12,28 @@ requires: ERC725Y
 
 ## Simple Summary
 
-This schema describes how a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key values can be described.
+This schema defines how a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key-value pairs can be described. It can be used as an abstract structure over the storage of an ERC725Y smart contract.
 
 ## Abstract
 
-ERC725Y allow smart contracts to store key value stores (`bytes32` > `bytes`).
-This schema allows to standardize the key values that can be used in ERC725Y sub standards.
+ERC725Y enables storing any data in a smart contract as `bytes32` > `bytes` key-value pairs.
+
+Although this improves the way to interact with the data stored, it remains difficult to understand the layout of the contract storage. This is because both the key and the value are addressed in raw bytes.
+
+This schema allows to standardize those keys and values so that they can be more easily accessed and interpreted. It can be used to create ERC725Y sub-standards, made of pre-defined sets of ERC725Y keys (Metadata Standards).
 
 ## Motivation
 
-This schema defines a way to make those key values automatically parsable, so a interface or smart contract knows how to read and interact with them. 
+A schema defines a blueprint for how a data store is constructed.
+
+In the context of smart contracts, it can offer a better view of how the data is organised and structured within the contract storage.
+
+Using a schema over ERC725Y enables those keys and values to be easily readable and automatically parsable. Contracts and interfaces can know how to read and interact with the storage of an ERC725Y smart contract.
+
+The benefit of such schema is to allow interfaces or smart contracts to better decode (read, parse and interpret) the data stored in an ERC725Y contract. On the other hand, it also enables interfaces and contracts to know how to correctly encode data, before being set on an ERC725Y contract.
 
 This schema is for example used in [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) based smart contracts like
 [LSP3-UniversalProfile](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-UniversalProfile-Metadata.md) and [LSP4-DigitalAsset-Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md).
-
 
 ## Specification
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -149,7 +149,7 @@ The `keyType` determines how the value(s) should be interpreted.
 | [`Singleton`](#singleton)  | A simple key  | e.g.: `bytes32(keccak256("MyKeyName"))`|
 | [`Array`](#array)  | an array spanning multiple ERC725Y keys  | e.g.: `bytes32(keccak256("MyKeyName[]"))`|
 | [`Mapping`](#mapping)  | a key that map two words  | e.g.: `bytes16(keccak256("MyKeyName"))` + `bytes12(0)` + `bytes4(keccak256("MapName"))`|
-| [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` | e.g.: `bytes8(keccak256("MyKeyName")) + `bytes4(0)` +  `bytes20(dynamicValue)` |
+| [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` | e.g.: `bytes8(keccak256("MyKeyName"))` + `bytes4(0)` +  `bytes20(dynamicValue)` |
 | [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  | e.g.: `bytes4(keccak256("MyKeyName"))` + `bytes4(0)` + `bytes2(keccak256("MapName"))` + `bytes2(0)` +  `bytes20(dynamicValue)` |
 
 For the mapping key types (`Mapping`, `Bytes20Mapping` and `Bytes20MappingWithGrouping`), the term *"word"* COULD describe:

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -214,8 +214,8 @@ Below is an example for the **Array** key named `LSP3IssuedAssets[]`.
     "name": "LSP3IssuedAssets[]",
     "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
     "keyType": "Array",
-    "valueType": "address", // describes the type of each elements
-    "valueContent": "Address" // describes the value of each elements
+    "valueType": "address", // describes the type of each element
+    "valueContent": "Address" // describes the value of each element
 }
 ```
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -116,7 +116,7 @@ In scenarios where an ERC725Y key is part of an LSP Standard (Metadata standard)
 - `N`: the **Standard Number** this key refers to.
 - `KeyName`: a short name for the ERC725Y key.
 
-*e.g.:* `LSP4TokenName`
+*e.g.:* `MyColourTheme`, `LSP4TokenName`
 
 
 ### `key`
@@ -129,7 +129,7 @@ The `key` is a `bytes32` value that acts as **unique identifier** for the key. I
 
 The `keyType` determines how the value(s) should be interpreted.
 
-|   |   |
+| `keyType` | Description  |
 |---|---|
 | [`Singleton`](#singleton)  | A simple key  |
 | [`Array`](#array)  | an array spanning multiple ERC725Y keys  |
@@ -155,7 +155,7 @@ The `valueType` is relevant for interfaces to know how a value MUST be encoded /
 
 The `valueType` can also be useful for type casting. It enables contracts or interfaces to know how to manipulate the data, and the limitations behind its type. To illustrate, an interface could know that it cannot set the value to `300` if its `valueType` is `uint8` (max `uint8` allowed = `255`).
 
-|   |   |
+| `valueType` | Description |
 |---|---|
 | `boolean`  | a value as either **true** or **false** |
 | `string`  | an UTF8 encoded string  |
@@ -181,7 +181,7 @@ To illustrate, a string could be interpreted in multiple ways, such as:
 
 Valid `valueContent` are:
 
-|   |   |
+| `valueContent` | Description  |
 |---|---|
 | `String`  | an UTF8 encoded string |
 | `Address`  | an address |
@@ -220,18 +220,21 @@ Below is an example of a Singleton key type:
 
 ### Array
 
-An array of elements, where element has the same `valueType`.
+An array of elements, where each element have the same `valueType`.
 
 > *The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
 > Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit.*
 
-**Requirements**
+**Requirements:**
 
-A key of **Array** type MUST follow the following requirements:
+A key of **Array** type MUST have the following requirements:
 
 - The `name` of the key MUST have a `[]` (square brackets).
 - The `key` itself MUST be the keccak256 hash digest of the **full key `name`, including the square brackets `[]`**
-- The key hash MUST contain the number of all elements, and is required to be updated when a new key element is added.
+- The value stored under the full key hash MUST contain the total number of elements (= array length). It MUST be updated every time a new element is added to the array.
+- The value stored under the full key hash **MUST be stored as `uint256`** (32 bytes long, padded left with leading zeros).
+
+**Construction:**
 
 An initial key of an array containing the array length constructed using `bytes32(keccak256(KeyName))`.
 Subsequent keys consist of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`.
@@ -242,15 +245,14 @@ For all other elements:
 - The second 16 bytes is a `uint128` of the number of the element
 - Elements start at number `0`
 
-This would looks as follows for `LSP3IssuedAssets[]`:
+*example:*
+
+Below is an example for the **Array** key named `LSP3IssuedAssets[]`.
 
 - element number: key: `0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0`, value: `0x0000000000000000000000000000000000000000000000000000000000000002` (2 elements)
 - element 1: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000`, value: `0x123...` (element 0)
 - element 2: key: `0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001`, value: `0x321...` (element 1)
 ...
-
-
-Below is an example of an Array key type:
 
 ```json
 {
@@ -261,8 +263,6 @@ Below is an example of an Array key type:
     "valueContent": "Address" // describes the value of each elements
 }
 ```
-
-*example:*
 
 ```solidity
 key: keccak256('LSP3IssuedAssets[]') = 0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -43,11 +43,66 @@ To make ERC725Y keys readable, we describe a key-value pair as a JSON object con
 }
 ```
 
-- [`name`]: describe the name of the key.
-- [`key`]: the **keccak256** hash of the `name`.
-- [`keyType`]: describe *how* the key MUST be treated.
-- [`valueType`]: describe *how* the value MUST be decoded.
-- [`valueContent`]: describe *how* a value SHOULD be treated.
+The table below describes each entries with their available options. 
+
+<table style="text-align: center">
+    <thead>
+        <tr>
+            <th style="text-align: center"><a href="#name"><code>name</code></th>
+            <th style="text-align: center"><a href="#key"><code>key</code></th>
+            <th style="text-align: center"><a href="#keyType"><code>keyType</code></th>
+            <th style="text-align: center"><a href="#valueType"><code>valueType</code></th>
+            <th style="text-align: center"><a href="#valueContent"><code>valueContent</code></th>
+        </tr>
+    </thead>
+    <tbody align="center">
+        <tr>
+            <td>
+                <p style="text-align: center">the name of the key</p>
+            </td>
+            <td style="text-align: center"><p>the <code>keccak256</code> hash of the <code>name</code></p></td>
+            <td style="text-align: center">
+                <p><i>How</i> the key MUST be <b>treated</b></p>
+                <p><a href="#singleton"><code>Singleton</code></a></p>
+                <p><a href="#array"><code>Array</code></a></p>
+                <p><a href="#mapping"><code>Mapping</code></a></p>
+                <p><a href="#bytes20mapping"><code>Bytes20Mapping</code></a></p>
+                <p><a href="#bytes20mappingwithgrouping"><code>Bytes20MappingWithGrouping</code></a></p>
+            </td>
+            <td align="center">
+                <p><i>How</i> a value MUST be <b>decoded</b></p>
+                <p><code>boolean</code></p>
+                <p><code>string</code></p>
+                <p><code>address</code></p>
+                <p><code>uintN</code></p>
+                <p><code>intN</code></p>
+                <p><code>bytesN</code></p>
+                <p><code>bytes</code></p>
+                <p><code>uintN[]</code></p>
+                <p><code>intN[]</code></p>
+                <p><code>string[]</code></p>
+                <p><code>address[]</code></p>
+                <p><code>bytes[]</code></p>
+            </td>
+            <td style="text-align: center">
+                <p><i>How</i> a value SHOULD be <b>interpreted</b></p>
+                <p><code>Boolean</code></p>
+                <p><code>String</code></p>
+                <p><code>Address</code></p>
+                <p><code>Number</code></p>
+                <p><code>BytesN</code></p>
+                <p><code>Bytes</code></p>
+                <p><code>Keccak256</code></p>
+                <p><code>BitArray</code></p>
+                <p><code>URL</code></p>
+                <p><a href="#asseturl"><code>AssetURL</code></a></p>
+                <p><a href="#jsonurl"><code>JSONURL</code></a></p>
+                <p><code>Markdown</code></p>
+                <p><code>Literal</code><br/> (<u>e.g.:</u> <code>0x1345ABCD...</code>)</p>
+            </td>
+        </tr>
+    </tbody>
+</table>
 
 
 ### `name`
@@ -140,8 +195,7 @@ Valid `valueContent` are:
 | `Markdown`  | a structured Markdown mostly encoded as UTF8 string  |
 | `0x1345ABCD...`  | a **literal** value, when the returned value is expected to equal some specific bytes |
 
-### Key Types explained
-#### Singleton
+### Singleton
 
 A simple key is constructed using `bytes32(keccak256("KeyName"))`,
 
@@ -159,7 +213,7 @@ Below is an example of a Singleton key type:
 
 `keccak256("MyKeyName")` = `0x`**`35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2`**
 
-#### Array
+### Array
 
 An array of elements, where element has the same `valueType`.
 
@@ -220,7 +274,7 @@ key: 0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001
 value: 0xcafecafecafecafecafecafecafecafecafecafe
 ```
 
-#### Mapping
+### Mapping
 
 A **Mapping** key is constructed using `bytes16(keccak256("FirstWord")) + bytes12(0) + bytes4(keccak256("SecondWord"))`.  
 
@@ -239,7 +293,11 @@ A **Mapping** key is constructed using `bytes16(keccak256("FirstWord")) + bytes1
 
 - `keccak256("FirstWord")` = `0x`<mark>`f49648de3734d6c5458244ad87c893b5`</mark>`0e6367d2cfa4670eddec109d1fc952e0` (**first 16 bytes** of the hash)
 - `keccak256("SecondWord")` = `0x`<mark>`53022d37`</mark>`21822ca6332135de9e7b98f9a82eb1051d3095d2e259b45149c9b634` (**first 4 bytes** of the hash)
-#### Bytes20Mapping
+
+<span style="background-color: red">Marked text</span>
+
+
+### Bytes20Mapping
 
 **Bytes20Mapping** could be used to map words to `bytes20` long data, such as `addresses`. Such key type can be useful when the second word in the mapping is too long and makes the key greater than 32 bytes.
 
@@ -257,7 +315,7 @@ A **Bytes20Mapping** mapping key is constructed using `bytes8(keccak256(FirstWor
 }
 ```
 
-#### Bytes20MappingWithGrouping
+### Bytes20MappingWithGrouping
 
 A **Bytes20MappingWithGrouping** key could be used to map two words to addresses, or other bytes 20 long data.
 This key is constructed using `bytes4(keccak256(FirstWord)) + bytes4(0) + bytes2(keccak256(SecondWord)) + bytes2(0) + bytes20(address)`,     
@@ -276,7 +334,7 @@ Below is an example of a mapping key type:
 }
 ```
 
-#### AssetURL
+### AssetURL
 
 The content is bytes containing the following format:
 `bytes4(keccack256('hashFunction'))` + `bytes32(keccack256(assetBytes))` + `utf8ToHex('AssetURL')`
@@ -323,7 +381,7 @@ keccak256(utf8)    hash                                                         
 0x8019f9b1d47cf10786205bb08ce508e91c424d413d0f6c48e24dbfde2920d16a9561a723697066733a2f2f516d57346e554e7933767476723344785a48754c66534c6e687a4b4d6532576d67735573454750504668385a7470
 ```
 
-#### JSONURL
+### JSONURL
 
 The content is bytes containing the following format:     
 `bytes4(keccak256('hashFunction'))` + `bytes32(keccak256(JSON.stringify(JSON)))` + `utf8ToHex('JSONURL')`

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -182,7 +182,7 @@ The `valueType` can also be useful for typecasting. It enables contracts or inte
 
 ### `valueContent`
 
-Describes how to interpret the content of the returned value.
+Describes how to interpret the content of the returned *decoded* value.
 
 To illustrate, a string could be interpreted in multiple ways, such as:
 - a single word, or a sequence of words (*e.g.: "My Custom Token Name"*)

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -43,11 +43,11 @@ To make ERC725Y keys readable, we describe a key-value pair as a JSON object con
 }
 ```
 
-- `name`: describe the name of the key.
-- `key`: the **keccak256** hash of the `name`.
-- `keyType`: describe *how* the key MUST be treated.
-- `valueType`: describe *how* the value MUST be decoded.
-- `valueContent`: describe *how* a value SHOULD be treated.
+- [`name`]: describe the name of the key.
+- [`key`]: the **keccak256** hash of the `name`.
+- [`keyType`]: describe *how* the key MUST be treated.
+- [`valueType`]: describe *how* the value MUST be decoded.
+- [`valueContent`]: describe *how* a value SHOULD be treated.
 
 
 ### `name`
@@ -84,7 +84,12 @@ The `keyType` determines how the value(s) should be interpreted.
 > **Note:** for the Mapping key types, the words MUST NOT contain ":" (colon character), as it is used for the delimiter between both words.
 ### `valueType`
 
-The type the content MUST be decoded with.
+Describes the underlying type for a value stored under a specific ERC725Y key. The `valueType` is relevant for interfaces to know how a value MUST be encoded / decoded. This include:
+
+- how to decode a value fetched via `ERC725Y.getData(...)`
+- how to encode a value that needs to be set via `ERC725Y.setData(...)`. 
+
+The `valueType` can also be useful for type casting. It enables contracts or interfaces to know how to manipulate the data, and the limitations behind its type. To illustrate, an interface could know that it cannot set the value to `300` if its `valueType` is `uint8` (max `uint8` allowed = `255`).
 
 |   |   |
 |---|---|

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -57,12 +57,11 @@ The table below describes each entries with their available options.
     </thead>
     <tbody align="center">
         <tr>
+            <td>the name of the key</td>
+            <td>the <code>keccak256</code> hash of the <code>name</code></td>
             <td>
-                <p style="text-align: center">the name of the key</p>
-            </td>
-            <td style="text-align: center"><p>the <code>keccak256</code> hash of the <code>name</code></p></td>
-            <td style="text-align: center">
-                <p><i>How</i> the key MUST be <b>treated</b></p>
+                <i>How</i> the key MUST be <b>treated</b>
+                <hr>
                 <p><a href="#singleton"><code>Singleton</code></a></p>
                 <p><a href="#array"><code>Array</code></a></p>
                 <p><a href="#mapping"><code>Mapping</code></a></p>
@@ -70,7 +69,8 @@ The table below describes each entries with their available options.
                 <p><a href="#bytes20mappingwithgrouping"><code>Bytes20MappingWithGrouping</code></a></p>
             </td>
             <td align="center">
-                <p><i>How</i> a value MUST be <b>decoded</b></p>
+                <i>How</i> a value MUST be <b>decoded</b>
+                <hr>
                 <p><code>boolean</code></p>
                 <p><code>string</code></p>
                 <p><code>address</code></p>
@@ -85,7 +85,8 @@ The table below describes each entries with their available options.
                 <p><code>bytes[]</code></p>
             </td>
             <td style="text-align: center">
-                <p><i>How</i> a value SHOULD be <b>interpreted</b></p>
+                <i>How</i> a value SHOULD be <b>interpreted</b>
+                <hr>
                 <p><code>Boolean</code></p>
                 <p><code>String</code></p>
                 <p><code>Address</code></p>
@@ -194,6 +195,10 @@ Valid `valueContent` are:
 | [`JSONURL`](#jsonurl)  |  hash function, hash and link to the JSON file |
 | `Markdown`  | a structured Markdown mostly encoded as UTF8 string  |
 | `0x1345ABCD...`  | a **literal** value, when the returned value is expected to equal some specific bytes |
+
+
+---
+
 
 ### Singleton
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -255,9 +255,7 @@ For the **Array** `keyType`, the initial `key` contains the total number of elem
 
 Each Array element can be accessed through its own `key`. The `key` of an Array element consists of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`, where:
 - `bytes16(keccak256(KeyName))` = The first 16 bytes are the keccak256 hash of the full Array key `name` (including the `[]`) (e.g.: `LSP3IssuedAssets[]`)
-- `bytes16(uint128(ArrayElementIndex))` = the position (= index) of the element in the array (NB: elements index access start at `0`)
-
-> NB: element index access starts at number `0`
+- `bytes16(uint128(ArrayElementIndex))` = the position (= index) of the element in the array (**NB**: elements index access start at `0`)
 
 *example:*
 
@@ -310,10 +308,8 @@ A **Mapping** key is constructed using `bytes16(keccak256("FirstWord")) + bytes1
 ```
 
 
-- `keccak256("FirstWord")` = `0x`<mark>`f49648de3734d6c5458244ad87c893b5`</mark>`0e6367d2cfa4670eddec109d1fc952e0` (**first 16 bytes** of the hash)
-- `keccak256("SecondWord")` = `0x`<mark>`53022d37`</mark>`21822ca6332135de9e7b98f9a82eb1051d3095d2e259b45149c9b634` (**first 4 bytes** of the hash)
-
-<span style="background-color: red">Marked text</span>
+- `keccak256("FirstWord")` = `0x`**`f49648de3734d6c5458244ad87c893b5`**`0e6367d2cfa4670eddec109d1fc952e0` (**first 16 bytes** of the hash)
+- `keccak256("SecondWord")` = `0x`**`53022d37`**`21822ca6332135de9e7b98f9a82eb1051d3095d2e259b45149c9b634` (**first 4 bytes** of the hash)
 
 
 ### Bytes20Mapping

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -54,7 +54,7 @@ To make ERC725Y keys readable, we describe a key-value pair as a JSON object con
 The table below describes each entries with their available options. 
 
 | Title | Description |
-|::----:-|::----:-|
+|:----|:----|
 |[`name`](#name)| the name of the key |
 |[`key`](#key)| the **unique identifier** of the key |
 |[`keyType`](#keyType)| *How* the key must be treated <hr> [`Singleton`](#Singleton) <br> [`Array`](#Array) <br> [`Mapping`](#Mapping) <br> [`Bytes20Mapping`](#Bytes20Mapping) <br> [`Bytes20MappingWithGrouping`](#Bytes20MappingWithGrouping) |

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -351,6 +351,25 @@ Each bit can be either set (`1`) or not (`0`). The point of the BitArray `valueC
 
 A BitArray can be used as a mapping of values to states (on/off, allowed/disallowed, locked/unlocked, valid/invalid), where the max number of available values that can be mapped is *n* bits.
 
+Below is an example of a mapping key type:
+
+```json
+{
+    "name": "MyPermissions",
+    "key": "0xaacedf1d8b2cc85524a881760315208fb03c6c26538760922d6b9dee915fd66a",
+    "keyType": "Singleton",
+    "valueType": "bytes32",
+    "valueContent": "BitArray"
+}
+
+> Permissions set to 0010
+`0x000000000000000000000a`
+
+> Permissions set to 0110
+`0x000000000000000000000a`
+
+```
+
 ### AssetURL
 
 The content is bytes containing the following format:

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -116,7 +116,7 @@ The table below describes each entries with their available options.
 
 ### `name`
 
-The `name` is the human-readable format of the ERC725Y key. It aims to abstract the representation of the ERC725Y key, and defines what the key represents. In most cases, it SHOULD highlights the intent behind the key.
+The `name` is the human-readable format of the ERC725Y key. It aims to abstract the representation of the ERC725Y key and defines what the key represents. In most cases, it SHOULD highlight the intent behind the key.
 
 In scenarios where an ERC725Y key is part of an LSP Standard (Metadata standard), the key `name` SHOULD be comprised of the following: `LSP{N}{KeyName}`, where
 
@@ -129,7 +129,7 @@ In scenarios where an ERC725Y key is part of an LSP Standard (Metadata standard)
 
 ### `key`
 
-The `key` is a `bytes32` value that acts as **unique identifier** for the key. It is the actual key that MUST be used to retrieve the value stored in the contract storage, via `ERC725Y.getData(bytes32 key)`.
+The `key` is a `bytes32` value that acts as the **unique identifier** for the key. It is the actual key that MUST be used to retrieve the value stored in the contract storage, via `ERC725Y.getData(bytes32 key)`.
 
 The standard `keccak256` hashing algorithm is used to generate this identifier. However, *how* the identifier is constructed varies, depending on the `keyType`:
 
@@ -137,7 +137,7 @@ The standard `keccak256` hashing algorithm is used to generate this identifier. 
 - for `Array` keys (see [`Array`](#array) section for more details)
   - an initial key containing the array length.
   - subsequent keys for array index access.
-- for mapping keys, see each mapping type seperately below.
+- for mapping keys, see each mapping type separately below.
 
 
 ### `keyType`
@@ -163,12 +163,12 @@ For the mapping key types, the *"word"* MUST NOT contain a ":" (colon character)
 
 Describes the underlying data type of a value stored under a specific ERC725Y key. It refers to the type for the smart contract language like [Solidity](https://docs.soliditylang.org).
 
-The `valueType` is relevant for interfaces to know how a value MUST be encoded / decoded. This include:
+The `valueType` is relevant for interfaces to know how a value MUST be encoded/decoded. This include:
 
 - how to decode a value fetched via `ERC725Y.getData(...)`
 - how to encode a value that needs to be set via `ERC725Y.setData(...)`. 
 
-The `valueType` can also be useful for type casting. It enables contracts or interfaces to know how to manipulate the data, and the limitations behind its type. To illustrate, an interface could know that it cannot set the value to `300` if its `valueType` is `uint8` (max `uint8` allowed = `255`).
+The `valueType` can also be useful for typecasting. It enables contracts or interfaces to know how to manipulate the data and the limitations behind its type. To illustrate, an interface could know that it cannot set the value to `300` if its `valueType` is `uint8` (max `uint8` allowed = `255`).
 
 | `valueType` | Description |
 |---|---|
@@ -177,8 +177,8 @@ The `valueType` can also be useful for type casting. It enables contracts or int
 | `address`  | a 20 bytes long address |
 | `uintN`  | an **unsigned** integer (= only positive number) of size `N`  |
 | `intN`  |a **signed** integer (= either positive or negative number) of size `N` |
-| `bytesN`  | a fixed-size bytes value of size `N`, from `bytes1` up to `bytes32` |
-| `bytes`  | a dynamically-size bytes value |
+| `bytesN`  | a bytes value of **fixed-size** `N`, from `bytes1` up to `bytes32` |
+| `bytes`  | a bytes value of **dynamic-size** |
 | `uintN[]`  | an array of **signed** integers |
 | `intN[]`  | an array of **unsigned** integers |
 | `string[]`  | an array of UTF8 encoded strings |
@@ -201,11 +201,11 @@ Valid `valueContent` are:
 | `String`  | an UTF8 encoded string |
 | `Address`  | an address |
 | `Number`  | a Number (positive or negative, depending on the `keyType`)  |
-| `BytesN`  | a bytes of **fixed-size** `N`  |
-| `Bytes`  | a bytes |
+| `BytesN`  | a bytes value of **fixed-size** `N`, from `bytes1` up to `bytes32`  |
+| `Bytes`  | a bytes value of **dynamic-size** |
 | `Keccak256`  | a 32 bytes long hash digest, obtained from the keccak256 hashing algorithm |
-| `BitArray`  | *TBD*  |
-| `URL`  | an URL encoded as UTF8 string  |
+| `BitArray`  | an array of single `1` or `0` bits |
+| `URL`  | an URL encoded as an UTF8 string |
 | [`AssetURL`](#asseturl)  | The content contains the hash function, hash and link to the asset file  |
 | [`JSONURL`](#jsonurl)  |  hash function, hash and link to the JSON file |
 | `Markdown`  | a structured Markdown mostly encoded as UTF8 string  |
@@ -217,7 +217,7 @@ Valid `valueContent` are:
 
 ### Singleton
 
-A simple key is constructed using `bytes32(keccak256("KeyName"))`,
+A **Singleton** key refers to a simple key. It is constructed using `bytes32(keccak256("KeyName"))`,
 
 Below is an example of a Singleton key type:
 
@@ -235,10 +235,10 @@ Below is an example of a Singleton key type:
 
 ### Array
 
-An array of elements, where each element have the same `valueType`.
+An array of elements, where each element has the same `valueType`.
 
-> *The advantage of the `keyType` Array over using simple array elements like `address[]`, is that the amount of elements that can be stored is unlimited.
-> Storing an encoded array as a value, will reuqire a set amount of gas, which can exceed the block gas limit.*
+> *The advantage of the `keyType` Array over a standard array of elements like `address[]`, is that the amount of elements that can be stored is unlimited.
+> Storing an encoded array as a value, will require a set amount of gas, which can exceed the block gas limit.*
 
 **Requirements:**
 
@@ -251,14 +251,13 @@ A key of **Array** type MUST have the following requirements:
 
 **Construction:**
 
-An initial key of an array containing the array length constructed using `bytes32(keccak256(KeyName))`.
-Subsequent keys consist of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`.
+For the **Array** `keyType`, the initial `key` contains the total number of elements stored in the Array (= array length). It is constructed using `bytes32(keccak256(KeyName))`.
 
-For all other elements:
+Each Array element can be accessed through its own `key`. The `key` of an Array element consists of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`, where:
+- `bytes16(keccak256(KeyName))` = The first 16 bytes are the keccak256 hash of the full Array key `name` (including the `[]`) (e.g.: `LSP3IssuedAssets[]`)
+- `bytes16(uint128(ArrayElementIndex))` = the position (= index) of the element in the array (NB: elements index access start at `0`)
 
-- The first 16 bytes are the first 16 bytes of the key hash
-- The second 16 bytes is a `uint128` of the number of the element
-- Elements start at number `0`
+> NB: element index access starts at number `0`
 
 *example:*
 


### PR DESCRIPTION
# What does this PR introduce?

Improve readability, layout and structure of LSP2 - ERC725Y JSON Schema.

➡️  **For a preview, see here:** https://github.com/CJ42/LIPs/blob/refactor/lsp2/LSPs/LSP-2-ERC725YJSONSchema.md

## New Features

- For `valueType`
  - added `boolean` type
  - added signed integers `intN`
  - [x] replaced `uint256` with `uintN`
  - [x] replaced `bytes32` with `bytesN`
- For `valueContent`
  - added `Boolean`
  - [x] added `BitArray`
  - used keyword `Literal` for constant value content like `0x13456ABCD...`


## Content

Most of the content has been improved, by adding more precisions on specifications and requirements. 

- improved content for **Simple Summary**, **Abstract** and **Motivation**.
- added table with quick links at the top for `name`, `key`, `keyType`, `valueType` and `valueContent`.
- created sections for `name`, `key`, `keyType`, `valueType` and `valueContent`
- added tables with available types for `keyType`, `valueType` and `valueContent`
- improved description of construction keys for **Array** and mappings
- [x] added explanation for `BitArray`