### PR TITLE
docs: add precision for unknown interface ID for "Mixed" map keys

### DIFF
--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -170,7 +170,7 @@ References issued smart contract assets, like tokens (_e.g.: [LSP7 Digital Asset
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where:
 - `indexNumber` = the index in the [`LSP3IssuedAssets[]` Array](#lsp3issuedassets)
-- `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements.
+- `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0x00000000`).
 
 ```json
 {

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -185,7 +185,9 @@ References the creator addresses for this asset.
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. 
 Where:
 - `indexNumber` = the index in the [`LSP4Creators[]` Array](#lsp3issuedassets)
-- `standardInterfaceId` = if the creator address is a smart contract, the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the smart contract implements. Otherwise `0x00000000`
+- `standardInterfaceId` = if the creator address is a smart contract, the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the smart contract implements. Otherwise `0x00000000` in the case where the creator address is:
+  - an Externally Owned Account, or 
+  - a contract implementing an unknown ERC165 interface ID.
 
 ```json
 {

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -187,7 +187,7 @@ Where:
 - `indexNumber` = the index in the [`LSP4Creators[]` Array](#lsp3issuedassets)
 - `standardInterfaceId` = if the creator address is a smart contract, the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the smart contract implements. Otherwise `0x00000000` in the case where the creator address is:
   - an Externally Owned Account, or 
-  - a contract implementing an unknown ERC165 interface ID.
+  - a contract implementing no ERC165 interface ID.
 
 ```json
 {

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -56,7 +56,7 @@ References received smart contract assets, like tokens (_e.g.: [LSP7 Digital Ass
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where: 
 - `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp3issuedassets)
-- `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements.
+- `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0x00000000`).
 
 ```json
 {


### PR DESCRIPTION
# What does this PR introduce?

For the following Map keys with a **Mixed** `valueContent`:
- `LSP3IssuedAssetsMap`
- `LSP4CreatorsMap`
- `LSP5ReceivedAssetsMap`

Add the following precision for second `bytes4` of the `valueContent`:

If the address is either an EOA, or a contract with an unknown interface ID, `standardInterfaceId = 0x00000000`