### PR TITLE
docs: Add LSP9Vault and LSP10ReceivedVaults Standards

### DIFF
--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -13,7 +13,11 @@ requires: LSP2
 This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key-value pairs that can be used to store addresses of received vaults in a [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
 
 ## Abstract
-This key value standard describes keys to be added to an [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract, that reference received vaults smart contracts. Two keys are proposed: `LSP10ReceivedVaults[]` to hold an array of addresses and `LSP10ReceivedVaultsMap` to hold a mapping of the index in the former array and an standards interface ID to be able to quickly tell different vaults standards apart without querying each other vaults smart contract directly. The key `LSP10ReceivedVaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md)).
+The following two keys (including their ERC725Y JSON schema) are proposed to represent vaults owned by a smart contract:
+- `LSP10ReceivedVaults[]` to hold an array of vault addresses
+- `LSP10ReceivedVaultsMap` to hold a mapping of the index in the former array and the interface ID of the standard used by the vault. This enables to quickly differentiate vaults standards apart without the need to query each vault smart contract separately. 
+
+The key `LSP10ReceivedVaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md)).
 
 ## Motivation
 To be able to display received vaults in a profile we need to keep track of all received vaults contract addresses. This is important for [LSP3 UniversalProfile](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md), but also Assets smart contracts via [LSP5-ReceivedAssets](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-5-ReceivedAssets.md) Standard.
@@ -61,7 +65,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 ## Implementation
 
 An implementation can be found in the [lukso-network/standards-scenarios](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/develop/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault);
-The below defines the JSON interface of the `LSP10ReceivedVaults`.
+Below is the ERC725Y JSON interface of the `LSP10ReceivedVaults`.
 
 ERC725Y JSON Schema `LSP10ReceivedVaults`:
 ```json

--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -10,7 +10,7 @@ requires: LSP2
 ---
 
 ## Simple Summary
-This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key values to store addresses of received vaults in a [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
+This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key-value pairs that can be used to store addresses of received vaults in a [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
 
 ## Abstract
 This key value standard describes keys to be added to an [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract, that reference received vaults smart contracts. Two keys are proposed: `LSP10ReceivedVaults[]` to hold an array of addresses and `LSP10ReceivedVaultsMap` to hold a mapping of the index in the former array and an standards interface ID to be able to quickly tell different vaults standards apart without querying each other vaults smart contract directly. The key `LSP10ReceivedVaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md)).
@@ -20,7 +20,7 @@ To be able to display received vaults in a profile we need to keep track of all 
 
 ## Specification
 
-Every contract that supports to the ERC725Account SHOULD have the following keys:
+Every contract that supports the LSP9Vault standard SHOULD have the following keys:
 
 ### ERC725Y Keys
 
@@ -60,7 +60,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 
 ## Implementation
 
-A implementation can be found in the [lukso-network/standards-scenarios](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/develop/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault);
+An implementation can be found in the [lukso-network/standards-scenarios](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/develop/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault);
 The below defines the JSON interface of the `LSP10ReceivedVaults`.
 
 ERC725Y JSON Schema `LSP10ReceivedVaults`:

--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -25,14 +25,14 @@ Every contract that supports to the ERC725Account SHOULD have the following keys
 ### ERC725Y Keys
 
 
-#### LSP10ReceivedAssets[]
+#### LSP10Vaults[]
 
 References issued smart contract vaults.
 
 ```json
 {
-    "name": "LSP10ReceivedVaults[]",
-    "key": "0xd8c6ec2b958bbebb976719e1eb233f126e0f355c63843f434220f9753b5ca9e5",
+    "name": "LSP10Vaults[]",
+    "key": "0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06",
     "keyType": "Array",
     "valueContent": "Address",
     "valueType": "address"
@@ -40,7 +40,7 @@ References issued smart contract vaults.
 ```
 
 
-#### LSP10ReceivedVaultsMap
+#### LSP10VaultsMap
 
 References issued smart contract vaults.
 
@@ -48,8 +48,8 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 
 ```json
 {
-    "name": "LSP10ReceivedVaultsMap:<address>",
-    "key": "0x5e5a4636eeb20bf100000000<address>",
+    "name": "LSP10VaultsMap:<address>",
+    "key": "0x192448c3c0f88c7f00000000<address>",
     "keyType": "Mapping",
     "valueContent": "Mixed",
     "valueType": "bytes"
@@ -67,15 +67,15 @@ ERC725Y JSON Schema `LSP10ReceivedVaults`:
 ```json
 [
     {
-        "name": "LSP10ReceivedVaultsMap:<address>",
-        "key": "0x5e5a4636eeb20bf100000000<address>",
+        "name": "LSP10VaultsMap:<address>",
+        "key": "0x192448c3c0f88c7f00000000<address>",
         "keyType": "Mapping",
         "valueContent": "Mixed",
         "valueType": "bytes"
     },
     {
-        "name": "LSP10ReceivedVaults[]",
-        "key": "0xd8c6ec2b958bbebb976719e1eb233f126e0f355c63843f434220f9753b5ca9e5",
+        "name": "LSP10Vaults[]",
+        "key": "0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06",
         "keyType": "Array",
         "valueContent": "Address",
         "valueType": "address"

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -21,7 +21,7 @@ This standard defines a vault that can hold assets and interact with other contr
 
 ## Motivation
 
-///
+### TODO
 
 ## Specification
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -16,7 +16,7 @@ This standard describes a version of an [ERC725](https://github.com/ethereum/EIP
  
 ## Abstract
 
-This standard defines a vault that can hold assets and interact with other contracts. It has the ability to **attach information** via [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) to itself, **execute, deploy or transfer value** to any other smart contract or EOA via [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x), it can be **notified of incoming assets** via the [LSP1-UniversalReceiver](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md) function.
+This standard defines a vault that can hold assets and interact with other contracts. It has the ability to **attach information** via [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) to itself, **execute, deploy or transfer value** to any other smart contract or EOA via [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x). It can be **notified of incoming assets** via the [LSP1-UniversalReceiver](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md) function.
 
 
 ## Motivation
@@ -71,7 +71,7 @@ The ERC725 general key value store allows for the ability to add any kind of inf
 
 ## Implementation
 
-A implementation can be found in the [lsp-universalprofile-smart-contracts](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/main/contracts/LSP9Vault) repository;
+An implementation can be found on the [lsp-universalprofile-smart-contracts](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/tree/main/contracts/LSP9Vault) repository;
 
 ERC725Y JSON Schema:
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -122,7 +122,7 @@ interface ILSP9  /* is ERC165 */ {
     // LSP0 possible keys:
     // LSP1UniversalReceiverDelegate: 0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47
     
-    function setData(bytes32[] memory key, bytes[] memory value) external; // onlyOwner
+    function setData(bytes32[] memory key, bytes[] memory value) external; // onlyAllowed (UniversalReceiverDelegate and Owner)
         
     
     // LSP1


### PR DESCRIPTION
## What does this PR introduce ?
- Create the standards for LSP9 and LSP10:
      - LSP9 Representing a blockchain digital vault based on ERC725 and LSP1-UniversalReceiver
      - LSP10 Representing metadata keys to list all vaults a UniversalProfile own.
      
Note: Still Missing Motivation