### PR TITLE
docs: use internal links to markdown files instead of urls

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -6,7 +6,7 @@ discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2021-09-21
-requires: ERC165, ERC173, ERC1271, ERC725X, ERC725Y, [LSP1](LSP-1-UniversalReceiver.md), LSP2
+requires: ERC165, ERC173, ERC1271, ERC725X, ERC725Y, LSP1, LSP2
 ---
 
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -6,7 +6,7 @@ discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2021-09-21
-requires: ERC165, ERC173, ERC1271, ERC725X, ERC725Y, LSP1, LSP2
+requires: ERC165, ERC173, ERC1271, ERC725X, ERC725Y, [LSP1](LSP-1-UniversalReceiver.md), LSP2
 ---
 
 
@@ -16,7 +16,7 @@ This standard describes a version of an [ERC725](https://github.com/ethereum/EIP
  
 ## Abstract
 
-This standard, defines a blockchain account system to be used by humans, machines, or other smart contracts. It has the ability to **attach information** via [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) to itself, **execute, deploy or transfer value** to any other smart contract or EOA via [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x), is able to **be notified of incoming assets** via the [LSP1-UniversalReceiver](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md) function, and can **verify signatures** via [ERC1271](https://eips.ethereum.org/EIPS/eip-1271).
+This standard, defines a blockchain account system to be used by humans, machines, or other smart contracts. It has the ability to **attach information** via [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) to itself, **execute, deploy or transfer value** to any other smart contract or EOA via [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x), is able to **be notified of incoming assets** via the [LSP1-UniversalReceiver](./LSP-1-UniversalReceiver.md) function, and can **verify signatures** via [ERC1271](https://eips.ethereum.org/EIPS/eip-1271).
 
 
 ## Motivation
@@ -30,10 +30,10 @@ Using EOAs as accounts makes it hard to reason about the actor behind an address
 To make the usage of Blockchain infrastructures easier we need to use a smart contract account, rather that EOAs directly as account system.
 This allows us to:
 
-- Make security upgradeable via a key manager smart contract (e.g. [LSP6 KeyManager](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-6-KeyManager.md))
+- Make security upgradeable via a key manager smart contract (e.g. [LSP6 KeyManager](./LSP-6-KeyManager.md))
 - Allow any action that an EOA can do, and even add the ability to use `create2` through [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x)
-- Allow the account to be informed and react to receiving assets through [LSP1 UniversalReciever](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md)
-- Define a number of key values stores to attach profile and other information through additional standards like [LSP3 UniversalProfile-Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-UniversalProfile-Metadata.md)
+- Allow the account to be informed and react to receiving assets through [LSP1 UniversalReciever](./LSP-1-UniversalReceiver.md)
+- Define a number of key values stores to attach profile and other information through additional standards like [LSP3 UniversalProfile-Metadata](./LSP-3-UniversalProfile-Metadata.md)
 - Allow signature verification through [ERC1271](https://eips.ethereum.org/EIPS/eip-1271)
 
 
@@ -65,7 +65,7 @@ this smart contract address MUST be stored under the following key:
 
 ### Methods
 
-Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) (General key-value store, and general executor), [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md) and [LSP1](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md), 
+Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General key-value store, and general executor), [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification) and [LSP1](./LSP-1-UniversalReceiver.md#specification), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
 ### Events
@@ -85,7 +85,7 @@ The ERC725 general key value store allows for the ability to add any kind of inf
 
 ## Implementation
 
-A implementation can be found in the [ERC725Alliance/ERC725](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725Account.sol) repository;
+An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol) repository.
 
 ERC725Y JSON Schema `ERC725Account`:
 

--- a/LSPs/LSP-1-UniversalReceiver.md
+++ b/LSPs/LSP-1-UniversalReceiver.md
@@ -95,11 +95,13 @@ _Returns:_ `bytes`, which can be used to encode response values.
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-This is an abstraction of the ideas behind Ethereum ERC223 and ERC777, that contracts are called when they are receiving tokens. With this proposal, we can allow contracts to receive any information over a standardised interface.
+This is an abstraction of the ideas behind Ethereum [ERC223](https://github.com/ethereum/EIPs/issues/223) and [ERC777](https://eips.ethereum.org/EIPS/eip-777), that contracts are called when they are receiving tokens. With this proposal, we can allow contracts to receive any information over a standardised interface.
 This can even be done in an upgradable way, where the receiving code can be changed over time to support new standards and assets. 
 
 
 ## Implementation
+
+An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/tree/develop/contracts/LSP1UniversalReceiver) repository.
 
 A solidity example of the described interface:
 

--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -17,10 +17,10 @@ The following two keys (including their ERC725Y JSON schema) are proposed to rep
 - `LSP10ReceivedVaults[]` to hold an array of vault addresses
 - `LSP10ReceivedVaultsMap` to hold a mapping of the index in the former array and the interface ID of the standard used by the vault. This enables to quickly differentiate vaults standards apart without the need to query each vault smart contract separately. 
 
-The key `LSP10ReceivedVaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md)).
+The key `LSP10ReceivedVaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
 
 ## Motivation
-To be able to display received vaults in a profile we need to keep track of all received vaults contract addresses. This is important for [LSP3 UniversalProfile](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md), but also Assets smart contracts via [LSP5-ReceivedAssets](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-5-ReceivedAssets.md) Standard.
+To be able to display received vaults in a profile we need to keep track of all received vaults contract addresses. This is important for [LSP3 UniversalProfile](./LSP-3-UniversalProfile.md), but also Assets smart contracts via [LSP5-ReceivedAssets](./LSP-5-ReceivedAssets.md) Standard.
 
 ## Specification
 

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -33,7 +33,7 @@ Using a standardised schema over ERC725Y enables those keys and values to be eas
 The advantage of such schema is to allow interfaces or smart contracts to better decode (read, parse and interpret) the data stored in an ERC725Y contract. It is less error-prone due to knowing data types upfront. On the other hand, it also enables interfaces and contracts to know how to correctly encode data, before being set on an ERC725Y contract.
 
 This schema is for example used in [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) based smart contracts like
-[LSP3-UniversalProfile](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-UniversalProfile-Metadata.md) and [LSP4-DigitalAsset-Metadata](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata.md).
+[LSP3-UniversalProfile](./LSP-3-UniversalProfile-Metadata.md#implementation) and [LSP4-DigitalAsset-Metadata](./LSP-4-DigitalAsset-Metadata.md#implementation).
 
 ## Specification
 

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -182,7 +182,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 }
 ```
 
-For more infos about how to access each index of the `LSP3IssuedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](./LSP-2-ERC725YJSONSchema.md#Array)
+For more informations about how to access each index of the `LSP3IssuedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](./LSP-2-ERC725YJSONSchema.md#Array)
 
 ## Rationale
 

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -16,7 +16,7 @@ This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob
  
 ## Abstract
 
-This standard, defines a set of key value stores that are useful to create a public on-chain profile, based on an [ERC725Account](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-0-ERC725Account.md).
+This standard, defines a set of key value stores that are useful to create a public on-chain profile, based on an [ERC725Account](./LSP-0-ERC725Account.md).
 
 ## Motivation
 
@@ -58,7 +58,7 @@ A JSON file that describes the profile information, including profile image, bac
 }
 ```
 
-For construction of the JSONURL value see: [ERC725Y JSON Schema](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl-example)
+For construction of the JSONURL value see: [ERC725Y JSON Schema](./LSP-2-ERC725YJSONSchema.md#JSONURL)
 
 The linked JSON file SHOULD have the following format:
 
@@ -162,7 +162,7 @@ An array of smart contract assets issued by the Universal Profile, like tokens (
 }
 ```
 
-For more info about how to access each index of the `LSP3IssuedAssets[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more info about how to access each index of the `LSP3IssuedAssets[]` array, see: [ERC725Y JSON Schema > `keyType`: `Array`](./LSP-2-ERC725YJSONSchema.md#Array)
 
 #### LSP3IssuedAssetsMap
 
@@ -182,7 +182,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 }
 ```
 
-For more infos about how to access each index of the `LSP3IssuedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about how to access each index of the `LSP3IssuedAssets[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](./LSP-2-ERC725YJSONSchema.md#Array)
 
 ## Rationale
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -91,7 +91,7 @@ The description of the asset.
 }
 ```
 
-For more infos about how to construct the JSONURL, see: [ERC725Y JSON Schema > `valueContent` > `JSONURL`](./LSP-2-ERC725YJSONSchema.md#JSONURL)
+For more informations about how to construct the JSONURL, see: [ERC725Y JSON Schema > `valueContent` > `JSONURL`](./LSP-2-ERC725YJSONSchema.md#JSONURL)
 
 The linked JSON file SHOULD have the following format:
 
@@ -176,7 +176,7 @@ An array of ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines t
 }
 ```
 
-For more infos about how to access each index of the `LSP4Creators[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](./LSP-2-ERC725YJSONSchema.md#Array)
+For more informations about how to access each index of the `LSP4Creators[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](./LSP-2-ERC725YJSONSchema.md#Array)
 
 #### LSP4CreatorsMap
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -15,7 +15,7 @@ This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob
 
 ## Abstract
 
-This standard, defines a set of key value stores that are useful to create digital asset.
+This standard, defines a set of key-value pairs that are useful to describe a digital asset.
 
 ## Motivation
 
@@ -23,7 +23,7 @@ This standard aims to create a better version of tokens and NFTs to allow more f
 As NFTs mostly have a creator, those creators should be able to improve the assets (link better 3D files, as 3D file standards improve), or change attributes.
 One could even think of a smart contract system that can increase attributes based on certain inputs automatically.
 
-An LSP4 asset is controlled by a single `owner`, expected to be a ERC725 smart contract. This owner is able to `setData`, and therefore change values of keys, and can potentially mint new items.
+An LSP4 Digital Asset is controlled by a single `owner`, expected to be a [ERC725](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md) smart contract. This owner is able to [`setData(...)`](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#setdata), and therefore change values of keys, and can potentially mint new items.
  
 
 ## Specification
@@ -91,7 +91,7 @@ The description of the asset.
 }
 ```
 
-For construction of the JSONURL value see: [ERC725Y JSON Schema](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl-example)
+For more infos about how to construct the JSONURL, see: [ERC725Y JSON Schema > `valueContent` > `JSONURL`](./LSP-2-ERC725YJSONSchema.md#JSONURL)
 
 The linked JSON file SHOULD have the following format:
 
@@ -176,7 +176,7 @@ An array of ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines t
 }
 ```
 
-For more infos about how to access each index of the `LSP4Creators[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about how to access each index of the `LSP4Creators[]` array, see [ERC725Y JSON Schema > `keyType`: `Array`](./LSP-2-ERC725YJSONSchema.md#Array)
 
 #### LSP4CreatorsMap
 
@@ -184,7 +184,7 @@ References the creator addresses for this asset.
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. 
 Where:
-- `indexNumber` = the index in the [`LSP4Creators[]` Array](#lsp3issuedassets)
+- `indexNumber` = the index in the [`LSP4Creators[]` Array](##lsp4creators)
 - `standardInterfaceId` = if the creator address is a smart contract, the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the smart contract implements. Otherwise `0x00000000` in the case where the creator address is:
   - an Externally Owned Account, or 
   - a contract implementing no ERC165 interface ID.
@@ -205,7 +205,7 @@ There can be many token implementations, and this standard fills a need for comm
 
 ## Implementation
 
-A implementation can be found in the [lukso-network/universalprofile-smart-contracts](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/blob/main/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol);
+An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/blob/main/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol) repository.
 The below defines the JSON interface of the `LSP4DigitalAsset`.
 
 ERC725Y JSON Schema `LSP4DigitalAsset`:

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -21,7 +21,7 @@ Two keys are proposed to reference received asset smart contracts.
   - the index in the former array where the received asset address is stored.
   - an [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) to easily identify the standard used by each asset smart contracts, without the need to query the contracts directly. 
 
-The key `LSP5ReceivedAssetsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. via an [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
+The key `LSP5ReceivedAssetsMap` also helps to prevent duplicates from being added to the array, when automatically added via smart contract (e.g. via an [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
 
 ## Motivation
 To be able to display received assets in a profile we need to keep track of all received asset contract addresses. This is important for [UniversalProfile](./LSP-3-UniversalProfile-Metadata.md), but also [Vault](./LSP-9-Vault.md) smart contracts.

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -21,10 +21,10 @@ Two keys are proposed to reference received asset smart contracts.
   - the index in the former array where the received asset address is stored.
   - an [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) to easily identify the standard used by each asset smart contracts, without the need to query the contracts directly. 
 
-The key `LSP5ReceivedAssetsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md)).
+The key `LSP5ReceivedAssetsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. via an [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
 
 ## Motivation
-To be able to display received assets in a profile we need to keep track of all received asset contract addresses. This is important for [LSP3 UniversalProfile-Metadata](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile-Metadata.md), but also Vault smart contracts.
+To be able to display received assets in a profile we need to keep track of all received asset contract addresses. This is important for [UniversalProfile](./LSP-3-UniversalProfile-Metadata.md), but also [Vault](./LSP-9-Vault.md) smart contracts.
 
 ## Specification
 
@@ -52,10 +52,10 @@ For more info about how to access each index of the `LSP5ReceivedAssets[]` array
 
 #### LSP5ReceivedAssetsMap
 
-References received smart contract assets, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset)_) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset)_).
+References received smart contract assets, like tokens (_e.g.: [LSP7 Digital Assets](./LSP-7-DigitalAsset.md)_) and NFTs (_e.g.: [LSP8 Identifiable Digital Assets](./LSP-8-IdentifiableDigitalAsset.md)_).
 
 The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. Where: 
-- `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp3issuedassets)
+- `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp5receivedassets)
 - `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0x00000000`).
 
 ```json

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -12,14 +12,14 @@ requires: ERC165, ERC1271, LSP2
 
 ## Simple Summary
 
-This standard describes a `KeyManager` contract with a set of pre-defined permissions for addresses. A KeyManager contract can control an [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) like account, or any other [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
+This standard describes a `KeyManager` contract with a set of pre-defined permissions for addresses. A KeyManager contract can control an [ERC725Account](./LSP-0-ERC725Account.md) like account, or any other [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
 
 
 ## Abstract
 
 This standard allows for controlling addresses to be restricted through multiple permissions, to act on and through this KeyManager on a controlled smart contract (for example an [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md)).
 
-The KeyManager functions as a gateway for the [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) restricting an address actions based on set permissions.
+The KeyManager functions as a gateway for the [ERC725Account](./LSP-0-ERC725Account.md) restricting an address actions based on set permissions.
 
 Permissions are described in the [Permissions values section](#permission-values-in-addresspermissionspermissionsaddress). Furthermore addresses can be restricted to only talk to certain other smart contracts or address, specific functions or smart contracts supporting only specifc standard interfaces.
 
@@ -34,9 +34,9 @@ The flow of a transactions is as follows:
 
 ## Motivation
 
-The benefit of a KeyManager is to externalise permission logic from [ERC725Y and X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) contracts (such as an [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md)). This allows for such an logic to be upgraded without needing to change the core [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) contract.
+The benefit of a KeyManager is to externalise permission logic from [ERC725Y and X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) contracts (such as an [ERC725Account](./LSP-0-ERC725Account.md)). This allows for such an logic to be upgraded without needing to change the core [ERC725Account](./LSP-0-ERC725Account.md) contract.
 
-Storing the permissions at the core [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) itself, allows it to survive KeyManager upgrades and opens the door to add additional KeyManager logic in the future, without loosing already set address permissions.
+Storing the permissions at the core [ERC725Account](./LSP-0-ERC725Account.md) itself, allows it to survive KeyManager upgrades and opens the door to add additional KeyManager logic in the future, without loosing already set address permissions.
 
 
 ## Specification
@@ -44,10 +44,10 @@ Storing the permissions at the core [ERC725Account](https://github.com/lukso-net
 
 ### ERC725Y Keys
 
-**The permissions that the KeyManager reads, are stored on the controlled-contracts ERC725Y key value store (for example an [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md))**
+**The permissions that the KeyManager reads, are stored on the controlled-contracts ERC725Y key value store (for example an [ERC725Account](./LSP-0-ERC725Account.md))**
 
 The following ERC725Y keys are used to read permissions of certain addresses.
-These keys are based on the [LSP2-ERC725YJSONSchema](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[Bytes20MappingWithGrouping](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#bytes20mappingwithgrouping)**
+These keys are based on the [LSP2-ERC725YJSONSchema](./LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[Bytes20MappingWithGrouping](./LSP-2-ERC725YJSONSchema.md#bytes20mappingwithgrouping)**
 
 
 #### AddressPermissions[]
@@ -65,7 +65,7 @@ This is mainly useful for interfaces to know which address hold permissions.
 }
 ```
 
-For more infos about how to access each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType` `Array`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#array)
+For more infos about how to access each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType` `Array`](./LSP-2-ERC725YJSONSchema.md#array)
 
 #### AddressPermissions:Permissions:\<address\>
 
@@ -148,7 +148,7 @@ Each key defined in the array MUST be 32 bytes long. It is possible to set a ran
 - some part of the keys as the exact key bytes
 - the rest of the key bytes as 0 bytes.
 
-The 0 bytes part will represent a part that is dynamic. To illustrate, using the example below for a [LSP2 Mapping](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#Mapping) key, where first word = `SupportedStandards`, and second word = `LSP3UniversalProfile`.
+The 0 bytes part will represent a part that is dynamic. To illustrate, using the example below for a [LSP2 Mapping](./LSP-2-ERC725YJSONSchema.md#Mapping) key, where first word = `SupportedStandards`, and second word = `LSP3UniversalProfile`.
 
 ```js
 name: "SupportedStandards:LSP3UniversalProfile"

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -34,7 +34,7 @@ The flow of a transactions is as follows:
 
 ## Motivation
 
-The benefit of a KeyManager is to externalise permission logic from [ERC725Y and X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) contracts (such as an [ERC725Account](./LSP-0-ERC725Account.md)). This allows for such an logic to be upgraded without needing to change the core [ERC725Account](./LSP-0-ERC725Account.md) contract.
+The benefit of a KeyManager is to externalise the permission logic from [ERC725Y and X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) contracts (such as an [ERC725Account](./LSP-0-ERC725Account.md)). This allows for such logic to be upgraded without needing to change the core [ERC725Account](./LSP-0-ERC725Account.md) contract.
 
 Storing the permissions at the core [ERC725Account](./LSP-0-ERC725Account.md) itself, allows it to survive KeyManager upgrades and opens the door to add additional KeyManager logic in the future, without loosing already set address permissions.
 
@@ -53,7 +53,7 @@ These keys are based on the [LSP2-ERC725YJSONSchema](./LSP-2-ERC725YJSONSchema.m
 #### AddressPermissions[]
 
 Contains an array of addresses, that have some permission set.
-This is mainly useful for interfaces to know which address hold permissions.
+This is mainly useful for interfaces to know which address holds which permissions.
 
 ```json
 {
@@ -65,7 +65,7 @@ This is mainly useful for interfaces to know which address hold permissions.
 }
 ```
 
-For more infos about how to access each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType` `Array`](./LSP-2-ERC725YJSONSchema.md#array)
+For more informations about how to access each index of the `AddressPermissions[]` array, see: [ERC725Y JSON Schema > `keyType` `Array`](./LSP-2-ERC725YJSONSchema.md#array)
 
 #### AddressPermissions:Permissions:\<address\>
 
@@ -85,8 +85,10 @@ Since the `valueType` of this key is `bytes32`, up to 255 different permissions 
     
 #### AddressPermissions:AllowedAddresses:\<address\>
 
-Contains an array of address (Externally Owned Accounts or smart contracts) a controlling address is allowed to interact with.
-IF no addresses are set, interacting with ANY addresses is allowed. IF one or more addresses is set, the controlling address is restricted to interact only with these addresses.
+Contains an array of addresses (Externally Owned Accounts or smart contracts) a controlling address is allowed to interact with.
+
+- IF **no addresses** are set, interacting with ANY addresses is allowed.
+- IF **one or more addresses** is set, the controlling address is restricted to interact only with these addresses.
 
 ```json
 {
@@ -102,7 +104,7 @@ IF no addresses are set, interacting with ANY addresses is allowed. IF one or mo
 
 Contains an array of [bytes4 function signatures](https://docs.soliditylang.org/en/v0.5.3/abi-spec.html?highlight=selector#function-selector), the controlling address is allowed to call on other smart contracts.
 
-This permission acts as a restriction mechanism for an interacting with other smart contracts via an ERC725Account. It enables to limit which functions an address can call on a external smart contracts via the ERC725Account.
+This permission acts as a restriction mechanism when interacting with other smart contracts via an ERC725Account. It enables to limit which functions an address can call on a external smart contracts via the ERC725Account.
 
 ```json
 {
@@ -187,7 +189,7 @@ SIGN               = 0x000000000000000000000000000000000000000000000000000000000
 function getNonce(address _address, uint256 _channel) public view returns (uint256)
 ```
 
-Returns the nonce that needs to be signed by a allowed key to be passed into the [executeRelayCall](#executeRelayCall) function. A signer can choose his channel number arbitrarily.
+Returns the nonce that needs to be signed by an allowed key to be passed into the [executeRelayCall](#executeRelayCall) function. A signer can choose his channel number arbitrarily.
 
 If multiple transactions should be signed, nonces in the same channel can simply be increased by increasing the returned nonce.
 

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -287,7 +287,7 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 
 [ERC20]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md>
 [ERC777]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-777.md>
-[LSP1]: <https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md>
-[LSP4#erc725ykeys]: <https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-4-DigitalAsset-Metadata.md#erc725ykeys>
-[LSP8]: <https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-8-IdentifiableDigitalAsset.md>
+[LSP1]: <./LSP-1-UniversalReceiver.md>
+[LSP4#erc725ykeys]: <./LSP-4-DigitalAsset-Metadata.md#erc725ykeys>
+[LSP8]: <./LSP-8-IdentifiableDigitalAsset.md>
 [LSP7.sol]: <https://github.com/lukso-network/lsp-universalprofile-smart-contracts/blob/main/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol>

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -478,10 +478,10 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [ERC721]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md>
 [ERC725]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md>
 [ERC777]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-777.md>
-[LSP1]: <https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md>
-[LSP2#jsonurl]: <https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl>
-[LSP2#bytes20mapping]: <https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#bytes20mapping>
-[LSP4#erc725ykeys]: <https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-4-DigitalAsset-Metadata.md#erc725ykeys>
-[LSP7]: <https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-7-DigitalAsset.md>
-[LSP8]: <https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-8-IdentifiableDigitalAsset.md>
+[LSP1]: <./LSP-1-UniversalReceiver.md>
+[LSP2#jsonurl]: <./LSP-2-ERC725YJSONSchema.md#JSONURL>
+[LSP2#bytes20mapping]: <./LSP-2-ERC725YJSONSchema.md#bytes20mapping>
+[LSP4#erc725ykeys]: <./LSP-4-DigitalAsset-Metadata.md#erc725ykeys>
+[LSP7]: <./LSP-7-DigitalAsset.md>
+[LSP8]: <./LSP-8-IdentifiableDigitalAsset.md>
 [LSP8.sol]: <https://github.com/lukso-network/lsp-universalprofile-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol>

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -16,7 +16,7 @@ This standard describes a version of an [ERC725](https://github.com/ethereum/EIP
  
 ## Abstract
 
-This standard defines a vault that can hold assets and interact with other contracts. It has the ability to **attach information** via [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) to itself, **execute, deploy or transfer value** to any other smart contract or EOA via [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x). It can be **notified of incoming assets** via the [LSP1-UniversalReceiver](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md) function.
+This standard defines a vault that can hold assets and interact with other contracts. It has the ability to **attach information** via [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) to itself, **execute, deploy or transfer value** to any other smart contract or EOA via [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x). It can be **notified of incoming assets** via the [LSP1-UniversalReceiver](./LSP-1-UniversalReceiver.md) function.
 
 
 ## Motivation
@@ -51,7 +51,7 @@ this smart contract address MUST be stored under the following key:
 
 ### Methods
 
-Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) (General value and execution) and [LSP1](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-1-UniversalReceiver.md), 
+Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) (General value and execution) and [LSP1](./LSP-1-UniversalReceiver.md), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
 ### Events


### PR DESCRIPTION
# What does this PR introduce?

To avoid broken links due to (potential) changes in the repo URL in the future, switch all the links from url to local markdown file reference.

This makes also the markdown file easier to read.