### PR TITLE
Update InterfaceId and Interface Cheat Sheet

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -39,7 +39,7 @@ This allows us to:
 
 ## Specification
 
-ERC165 interface id: `0x63cb749b`
+ERC165 interface id: `0x481e0fe8`
 
 _This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, ERC1271-isValidSignature, to allow detection of ERC725Accounts._
 
@@ -139,9 +139,14 @@ interface ILSP0  /* is ERC165 */ {
     event DataChanged(bytes32 indexed key, bytes value);
 
 
-    function getData(bytes32[] memory key) external view returns (bytes[] memory value);
+    function getData(bytes32 key) external view returns (bytes memory value);
     
-    function setData(bytes32[] memory key, bytes[] memory value) external; // onlyOwner
+    function setData(bytes32 key, bytes memory value) external; // onlyOwner
+
+    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+
+    function setData(bytes32[] memory keys, bytes[] memory values) external; // onlyOwner
+    
     
     // LSP0 possible keys:
     // LSP1UniversalReceiverDelegate: 0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -248,9 +248,13 @@ interface ILSP7 is /* IERC165 */ {
     event DataChanged(bytes32 indexed key, bytes value);
 
 
-    function getData(bytes32 _key) external view returns (bytes memory _value);
+    function getData(bytes32 key) external view returns (bytes memory value);
+    
+    function setData(bytes32 key, bytes memory value) external; // onlyOwner
 
-    function setData(bytes32 _key, bytes memory _value) external; // onlyOwner
+    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+
+    function setData(bytes32[] memory keys, bytes[] memory values) external; // onlyOwner
 
 
     // LSP7

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -434,9 +434,13 @@ interface ILSP8 is /* IERC165 */ {
     event DataChanged(bytes32 indexed key, bytes value);
 
 
-    function getData(bytes32 _key) external view returns (bytes memory _value);
+    function getData(bytes32 key) external view returns (bytes memory value);
+    
+    function setData(bytes32 key, bytes memory value) external; // onlyOwner
 
-    function setData(bytes32 _key, bytes memory _value) external; // onlyOwner
+    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+
+    function setData(bytes32[] memory keys, bytes[] memory values) external; // onlyOwner
 
 
     // LSP8

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -25,7 +25,7 @@ This standard defines a vault that can hold assets and interact with other contr
 
 ## Specification
 
-ERC165 interface id: `0x75edcee5`
+ERC165 interface id: `0x5e38b596`
 
 _This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, to allow detection of Vaults._
 
@@ -116,14 +116,17 @@ interface ILSP9  /* is ERC165 */ {
     
     
     function execute(uint256 operationType, address to, uint256 value, bytes memory data) external payable returns (bytes memory); // onlyOwner
+
+    function getData(bytes32 key) external view returns (bytes memory value);
     
-    function getData(bytes32[] memory key) external view returns (bytes[] memory value);
+    function setData(bytes32 key, bytes memory value) external; // onlyAllowed (UniversalReceiverDelegate and Owner)
     
+    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+    
+    function setData(bytes32[] memory keys, bytes[] memory values) external; // onlyAllowed (UniversalReceiverDelegate and Owner)
+        
     // LSP0 possible keys:
     // LSP1UniversalReceiverDelegate: 0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47
-    
-    function setData(bytes32[] memory key, bytes[] memory value) external; // onlyAllowed (UniversalReceiverDelegate and Owner)
-        
     
     // LSP1
 


### PR DESCRIPTION
## What does this PR introduce?
- Adding function overloading in the Interface Cheat Sheet of LSP0, LSP7, LSP8, LSP9.
- Updating InterfaceID of LSP0, LSP9.

### New InterfaceID:
- ERC725Account: `0x481e0fe8`
- LSP9Vault: `0x5e38b596 `