### PR TITLE
fix: errors in JSON schemas of keys

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -39,11 +39,11 @@ This allows us to:
 
 ## Specification
 
-ERC165 interface id: `0x481e0fe8`
+[ERC165] interface id: `0x481e0fe8`
 
 _This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, ERC1271-isValidSignature, to allow detection of ERC725Accounts._
 
-Every contract that supports the ERC725Account SHOULD implement:
+Every contract that supports the LSP0 standard (ERC725Account) SHOULD implement:
 
 ### ERC725Y Keys
 
@@ -174,3 +174,5 @@ interface ILSP0  /* is ERC165 */ {
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[ERC165]: <https://eips.ethereum.org/EIPS/eip-165>

--- a/LSPs/LSP-1-UniversalReceiver.md
+++ b/LSPs/LSP-1-UniversalReceiver.md
@@ -31,7 +31,7 @@ In cases where smart contracts function as a profile or wallet over a long time,
 
 ## Specification
 
-ERC165 interface id: `0x6bb56a14`
+[ERC165] interface id: `0x6bb56a14`
 
 Every contract that complies with the Universal Receiver standard MUST implement:
 
@@ -270,3 +270,5 @@ interface ILSP1Delegate  /* is ERC165 */ {
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[ERC165]: <https://eips.ethereum.org/EIPS/eip-165>

--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -54,7 +54,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 {
     "name": "LSP10VaultsMap:<address>",
     "key": "0x192448c3c0f88c7f00000000<address>",
-    "keyType": "Mapping",
+    "keyType": "Bytes20Mapping",
     "valueContent": "Mixed",
     "valueType": "bytes"
 }
@@ -73,7 +73,7 @@ ERC725Y JSON Schema `LSP10ReceivedVaults`:
     {
         "name": "LSP10VaultsMap:<address>",
         "key": "0x192448c3c0f88c7f00000000<address>",
-        "keyType": "Mapping",
+        "keyType": "Bytes20Mapping",
         "valueContent": "Mixed",
         "valueType": "bytes"
     },

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -12,7 +12,7 @@ requires: ERC725Y
 
 ## Simple Summary
 
-ERC725Y JSON Schema describes a single key-value pair stored by [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md). It is intended to be used as an abstract structure over the storage of an ERC725Y smart contract.
+ERC725Y JSON Schema describes a single key-value pair stored in a [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) contract. It is intended to be used as an abstract structure over the storage of an ERC725Y smart contract.
 
 ## Abstract
 

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -200,7 +200,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 {
     "name": "LSP3IssuedAssetsMap:<address>",
     "key": "0x83f5e77bfb14241600000000<address>",
-    "keyType": "Mapping",
+    "keyType": "Bytes20Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"
 }
@@ -239,7 +239,7 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
     {
         "name": "LSP3IssuedAssetsMap:<address>",
         "key": "0x83f5e77bfb14241600000000<address>",
-        "keyType": "Mapping",
+        "keyType": "Bytes20Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     },
@@ -255,7 +255,7 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
     {
         "name": "LSP5ReceivedAssetsMap:<address>",
         "key": "0x812c4334633eb81600000000<address>",
-        "keyType": "Mapping",
+        "keyType": "Bytes20Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     },

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -212,7 +212,7 @@ Where:
 {
     "name": "LSP4CreatorsMap:<address>",
     "key": "0x6de85eaf5d982b4e00000000<address>",
-    "keyType": "Mapping",
+    "keyType": "Bytes20Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"
 }
@@ -262,7 +262,7 @@ ERC725Y JSON Schema `LSP4DigitalAsset`:
     {
         "name": "LSP4CreatorsMap:<address>",
         "key": "0x6de85eaf5d982b4e00000000<address>",
-        "keyType": "Mapping",
+        "keyType": "Bytes20Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     },

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -62,7 +62,7 @@ The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4
 {
     "name": "LSP5ReceivedAssetsMap:<address>",
     "key": "0x812c4334633eb81600000000<address>",
-    "keyType": "Mapping",
+    "keyType": "Bytes20Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"
 }
@@ -80,7 +80,7 @@ ERC725Y JSON Schema `LSP5ReceivedAssets`:
     {
         "name": "LSP5ReceivedAssetsMap:<address>",
         "key": "0x812c4334633eb81600000000<address>",
-        "keyType": "Mapping",
+        "keyType": "Bytes20Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     },

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -430,4 +430,4 @@ interface ILSP6  /* is ERC165 */ {
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 
-[ERC725Account]: <./LSP-0-ERC725Account.md)>
+[ERC725Account]: <../LSP-0-ERC725Account.md)>

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -6,7 +6,7 @@ discussions-to:
 status: Draft
 type: LSP
 created: 2021-08-03
-requires: ERC165, ERC1271, LSP2
+requires: [ERC165], ERC1271, LSP2
 ---
 
 
@@ -40,6 +40,10 @@ Storing the permissions at the core [ERC725Account] itself, allows it to survive
 
 
 ## Specification
+
+[ERC165] interface id: `0x32e6d0ab`
+
+Every contract that supports the LSP6 standard SHOULD implement:
 
 
 ### ERC725Y Keys
@@ -430,4 +434,5 @@ interface ILSP6  /* is ERC165 */ {
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 
+[ERC165]: <https://eips.ethereum.org/EIPS/eip-165>
 [ERC725Account]: <./LSP-0-ERC725Account.md>

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -182,6 +182,16 @@ SIGN               = 0x000000000000000000000000000000000000000000000000000000000
 
 ### Methods
 
+#### account
+
+```solidity
+function account() external view returns (uint256)
+```
+
+Returns the `address` of the ERC725 Account linked with this Key Manager. The linked account can be one of the following:
+- ERC725X contract
+- ERC725Y contract
+- an ERC725 contract, implementing both ERC725X and ERC725Y.
 
 #### getNonce
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -6,7 +6,7 @@ discussions-to:
 status: Draft
 type: LSP
 created: 2021-08-03
-requires: [ERC165], ERC1271, LSP2
+requires: ERC165, ERC1271, LSP2
 ---
 
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -430,4 +430,4 @@ interface ILSP6  /* is ERC165 */ {
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 
-[ERC725Account]: <../LSP-0-ERC725Account.md>
+[ERC725Account]: <./LSP-0-ERC725Account.md>

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -430,4 +430,4 @@ interface ILSP6  /* is ERC165 */ {
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 
-[ERC725Account]: <../LSP-0-ERC725Account.md)>
+[ERC725Account]: <../LSP-0-ERC725Account.md>

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -12,18 +12,18 @@ requires: ERC165, ERC1271, LSP2
 
 ## Simple Summary
 
-This standard describes a `KeyManager` contract with a set of pre-defined permissions for addresses. A KeyManager contract can control an [ERC725Account](./LSP-0-ERC725Account.md) like account, or any other [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
+This standard describes a `KeyManager` contract with a set of pre-defined permissions for addresses. A KeyManager contract can control an [ERC725Account] like account, or any other [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
 
 
 ## Abstract
 
-This standard allows for controlling addresses to be restricted through multiple permissions, to act on and through this KeyManager on a controlled smart contract (for example an [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md)).
+This standard allows for controlling addresses to be restricted through multiple permissions, to act on and through this KeyManager on a controlled smart contract (for example an [ERC725Account]).
 
-The KeyManager functions as a gateway for the [ERC725Account](./LSP-0-ERC725Account.md) restricting an address actions based on set permissions.
+The KeyManager functions as a gateway for the [ERC725Account] restricting an address actions based on set permissions.
 
 Permissions are described in the [Permissions values section](#permission-values-in-addresspermissionspermissionsaddress). Furthermore addresses can be restricted to only talk to certain other smart contracts or address, specific functions or smart contracts supporting only specifc standard interfaces.
 
-The Permissions are stored at [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) ERC725Y key value store, and can therefore survive an upgrade to a new KeyManager contract.
+The Permissions are stored at [ERC725Account] ERC725Y key value store, and can therefore survive an upgrade to a new KeyManager contract.
 
 The flow of a transactions is as follows:
 
@@ -34,9 +34,9 @@ The flow of a transactions is as follows:
 
 ## Motivation
 
-The benefit of a KeyManager is to externalise the permission logic from [ERC725Y and X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) contracts (such as an [ERC725Account](./LSP-0-ERC725Account.md)). This allows for such logic to be upgraded without needing to change the core [ERC725Account](./LSP-0-ERC725Account.md) contract.
+The benefit of a KeyManager is to externalise the permission logic from [ERC725Y and X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) contracts (such as an [ERC725Account]). This allows for such logic to be upgraded without needing to change the core [ERC725Account] contract.
 
-Storing the permissions at the core [ERC725Account](./LSP-0-ERC725Account.md) itself, allows it to survive KeyManager upgrades and opens the door to add additional KeyManager logic in the future, without loosing already set address permissions.
+Storing the permissions at the core [ERC725Account] itself, allows it to survive KeyManager upgrades and opens the door to add additional KeyManager logic in the future, without loosing already set address permissions.
 
 
 ## Specification
@@ -44,7 +44,7 @@ Storing the permissions at the core [ERC725Account](./LSP-0-ERC725Account.md) it
 
 ### ERC725Y Keys
 
-**The permissions that the KeyManager reads, are stored on the controlled-contracts ERC725Y key value store (for example an [ERC725Account](./LSP-0-ERC725Account.md))**
+**The permissions that the KeyManager reads, are stored on the controlled-contracts ERC725Y key value store (for example an [ERC725Account])**
 
 The following ERC725Y keys are used to read permissions of certain addresses.
 These keys are based on the [LSP2-ERC725YJSONSchema](./LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[Bytes20MappingWithGrouping](./LSP-2-ERC725YJSONSchema.md#bytes20mappingwithgrouping)**
@@ -188,10 +188,10 @@ SIGN               = 0x000000000000000000000000000000000000000000000000000000000
 function account() external view returns (uint256)
 ```
 
-Returns the `address` of the ERC725 Account linked with this Key Manager. The linked account can be one of the following:
+Returns the `address` of the account linked with this Key Manager. The linked account can be one of the following:
 - ERC725X contract
 - ERC725Y contract
-- an ERC725 contract, implementing both ERC725X and ERC725Y.
+- an ERC725 contract, implementing both ERC725X and ERC725Y (e.g: an [ERC725Account].
 
 #### getNonce
 
@@ -428,3 +428,6 @@ interface ILSP6  /* is ERC165 */ {
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+
+[ERC725Account]: <./LSP-0-ERC725Account.md)>

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -189,13 +189,13 @@ SIGN               = 0x000000000000000000000000000000000000000000000000000000000
 #### account
 
 ```solidity
-function account() external view returns (uint256)
+function account() external view returns (address)
 ```
 
 Returns the `address` of the account linked with this Key Manager. The linked account can be one of the following:
 - ERC725X contract
 - ERC725Y contract
-- an ERC725 contract, implementing both ERC725X and ERC725Y (e.g: an [ERC725Account].
+- an ERC725 contract, implementing both ERC725X and ERC725Y (e.g: an [ERC725Account]).
 
 #### getNonce
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -410,8 +410,10 @@ interface ILSP6  /* is ERC165 */ {
     
     // LSP6
         
-    event Executed(uint256 indexed  _value, bytes _data); 
-    
+    event Executed(uint256 indexed  _value, bytes _data);
+
+
+    function account() external view returns (address);
     
     function getNonce(address _address, uint256 _channel) external view returns (uint256);
     

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -29,6 +29,10 @@ A commonality with [LSP8 IdentifiableDigitalAsset][LSP8] is desired so that the 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wikwi/wiki/Clients)).-->
 
+[ERC165] interface id: `0xe33f65c3`
+
+Every contract that supports the LSP7 standard SHOULD implement:
+
 ### ERC725Y Keys
 
 This standard expects the keys from [LSP4 DigitalAsset-Metadata][LSP4#erc725ykeys].
@@ -289,6 +293,7 @@ interface ILSP7 is /* IERC165 */ {
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 
+[ERC165]: <https://eips.ethereum.org/EIPS/eip-165>
 [ERC20]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md>
 [ERC777]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-777.md>
 [LSP1]: <./LSP-1-UniversalReceiver.md>

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -31,6 +31,10 @@ A commonality with [LSP7 DigitalAsset][LSP7] is desired so that the two token im
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wikwi/wiki/Clients)).-->
 
+[ERC165] interface id: `0x49399145`
+
+Every contract that supports the LSP8 standard SHOULD implement:
+
 ### ERC725Y Keys
 
 These are the expected keys for the LSP8 contract which mints tokens.
@@ -478,7 +482,7 @@ interface ILSP8 is /* IERC165 */ {
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-
+[ERC165]: <https://eips.ethereum.org/EIPS/eip-165>
 [ERC721]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md>
 [ERC725]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md>
 [ERC777]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-777.md>

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -25,11 +25,11 @@ This standard defines a vault that can hold assets and interact with other contr
 
 ## Specification
 
-ERC165 interface id: `0x5e38b596`
+[ERC165] interface id: `0x5e38b596`
 
 _This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, to allow detection of Vaults._
 
-Every contract that supports to the Vaults SHOULD implement:
+Every contract that supports the LSP9 standard SHOULD implement:
 
 ### ERC725Y Keys
 
@@ -144,3 +144,5 @@ interface ILSP9  /* is ERC165 */ {
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[ERC165]: <https://eips.ethereum.org/EIPS/eip-165>


### PR DESCRIPTION
# What does this PR introduce?

All of the ERC725Y JSON Schema of the keys with a `Map` keyword at the end (or in other words that have `<address>`:

- are defined as `Mapping` ❌ 
- but should `Bytes20Mapping` ✅ 