### PR TITLE
docs: replace keys by data keys

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -32,8 +32,8 @@ This allows us to:
 
 - Make security upgradeable via a key manager smart contract (e.g. [LSP6 KeyManager](./LSP-6-KeyManager.md))
 - Allow any action that an EOA can do, and even add the ability to use `create2` through [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x)
-- Allow the account to be informed and react to receiving assets through [LSP1 UniversalReciever](./LSP-1-UniversalReceiver.md)
-- Define a number of data key values stores to attach profile and other information through additional standards like [LSP3 UniversalProfile-Metadata](./LSP-3-UniversalProfile-Metadata.md)
+- Allow the account to be informed and react to receiving assets through [LSP1 UniversalReceiver](./LSP-1-UniversalReceiver.md)
+- Define a number of data key-values pairs to attach profile and other information through additional standards like [LSP3 UniversalProfile-Metadata](./LSP-3-UniversalProfile-Metadata.md)
 - Allow signature verification through [ERC1271](https://eips.ethereum.org/EIPS/eip-1271)
 
 
@@ -81,7 +81,7 @@ MUST be emitted when a native token transfer was received.
 
 ## Rationale
 
-The ERC725 general data key value store allows for the ability to add any kind of information to the the account contract, which allows future use cases. The general executor allows full interactability with any smart contract or address. And the universal receiver allows the reaction to any future asset.
+The ERC725Y general data key-value store allows for the ability to add any kind of information to the the account contract, which allows future use cases. The general executor allows full interactability with any smart contract or address. And the universal receiver allows reacting to any future asset received.
 
 ## Implementation
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -33,7 +33,7 @@ This allows us to:
 - Make security upgradeable via a key manager smart contract (e.g. [LSP6 KeyManager](./LSP-6-KeyManager.md))
 - Allow any action that an EOA can do, and even add the ability to use `create2` through [ERC725X](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x)
 - Allow the account to be informed and react to receiving assets through [LSP1 UniversalReciever](./LSP-1-UniversalReceiver.md)
-- Define a number of key values stores to attach profile and other information through additional standards like [LSP3 UniversalProfile-Metadata](./LSP-3-UniversalProfile-Metadata.md)
+- Define a number of data key values stores to attach profile and other information through additional standards like [LSP3 UniversalProfile-Metadata](./LSP-3-UniversalProfile-Metadata.md)
 - Allow signature verification through [ERC1271](https://eips.ethereum.org/EIPS/eip-1271)
 
 
@@ -45,13 +45,13 @@ _This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, ERC12
 
 Every contract that supports the ERC725Account SHOULD implement:
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
 
 #### LSP1UniversalReceiverDelegate
 
 If the account delegates its universal receiver to another smart contract,
-this smart contract address MUST be stored under the following key:
+this smart contract address MUST be stored under the following data key:
 
 ```json
 {
@@ -65,7 +65,7 @@ this smart contract address MUST be stored under the following key:
 
 ### Methods
 
-Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General key-value store, and general executor), [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification) and [LSP1](./LSP-1-UniversalReceiver.md#specification), 
+Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor), [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification) and [LSP1](./LSP-1-UniversalReceiver.md#specification), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
 ### Events
@@ -81,7 +81,7 @@ MUST be emitted when a native token transfer was received.
 
 ## Rationale
 
-The ERC725 general key value store allows for the ability to add any kind of information to the the account contract, which allows future use cases. The general executor allows full interactability with any smart contract or address. And the universal receiver allows the reaction to any future asset.
+The ERC725 general data key value store allows for the ability to add any kind of information to the the account contract, which allows future use cases. The general executor allows full interactability with any smart contract or address. And the universal receiver allows the reaction to any future asset.
 
 ## Implementation
 
@@ -136,19 +136,19 @@ interface ILSP0  /* is ERC165 */ {
     
     // ERC725Y
 
-    event DataChanged(bytes32 indexed key, bytes value);
+    event DataChanged(bytes32 indexed dataKey, bytes value);
 
 
-    function getData(bytes32 key) external view returns (bytes memory value);
+    function getData(bytes32 dataKey) external view returns (bytes memory value);
     
-    function setData(bytes32 key, bytes memory value) external; // onlyOwner
+    function setData(bytes32 dataKey, bytes memory value) external; // onlyOwner
 
-    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory values);
 
-    function setData(bytes32[] memory keys, bytes[] memory values) external; // onlyOwner
+    function setData(bytes32[] memory dataKeys, bytes[] memory values) external; // onlyOwner
     
     
-    // LSP0 possible keys:
+    // LSP0 possible data keys:
     // LSP1UniversalReceiverDelegate: 0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47
 
     
@@ -164,7 +164,7 @@ interface ILSP0  /* is ERC165 */ {
 
     function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory);
     
-    // IF LSP1UniversalReceiverDelegate key is set
+    // IF LSP1UniversalReceiverDelegate data key is set
     // THEN calls will be forwarded to the address given (UniversalReceiver even MUST still be fired)
 }
 

--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -10,23 +10,23 @@ requires: LSP2
 ---
 
 ## Simple Summary
-This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key-value pairs that can be used to store addresses of received vaults in a [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
+This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) data key-value pairs that can be used to store addresses of received vaults in a [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
 
 ## Abstract
-The following two keys (including their ERC725Y JSON schema) are proposed to represent vaults owned by a smart contract:
+The following two data keys (including their ERC725Y JSON schema) are proposed to represent vaults owned by a smart contract:
 - `LSP10ReceivedVaults[]` to hold an array of vault addresses
 - `LSP10ReceivedVaultsMap` to hold a mapping of the index in the former array and the interface ID of the standard used by the vault. This enables to quickly differentiate vaults standards apart without the need to query each vault smart contract separately. 
 
-The key `LSP10ReceivedVaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
+The data key `LSP10ReceivedVaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
 
 ## Motivation
 To be able to display received vaults in a profile we need to keep track of all received vaults contract addresses. This is important for [LSP3 UniversalProfile](./LSP-3-UniversalProfile.md), but also Assets smart contracts via [LSP5-ReceivedAssets](./LSP-5-ReceivedAssets.md) Standard.
 
 ## Specification
 
-Every contract that supports the LSP9Vault standard SHOULD have the following keys:
+Every contract that supports the LSP9Vault standard SHOULD have the following data keys:
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
 
 #### LSP10Vaults[]

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -12,15 +12,15 @@ requires: ERC725Y
 
 ## Simple Summary
 
-This schema defines how a single [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key-value pair can be described. It can be used as an abstract structure over the storage of an ERC725Y smart contract.
+This schema defines how a single [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) data key-value pair can be described. It can be used as an abstract structure over the storage of an ERC725Y smart contract.
 
 ## Abstract
 
-ERC725Y enables storing any data in a smart contract as `bytes32 => bytes` key-value pairs.
+ERC725Y enables storing any data in a smart contract as `bytes32 => bytes` data key-value pairs.
 
-Although this improves interaction with the data stored, it remains difficult to understand the layout of the contract storage. This is because both the key and the value are addressed in raw bytes.
+Although this improves interaction with the data stored, it remains difficult to understand the layout of the contract storage. This is because both the data key and the value are addressed in raw bytes.
 
-This schema allows to standardize those keys and values so that they can be more easily accessed and interpreted. It can be used to create ERC725Y sub-standards, made of pre-defined sets of ERC725Y keys.
+This schema allows to standardize those data keys and values so that they can be more easily accessed and interpreted. It can be used to create ERC725Y sub-standards, made of pre-defined sets of ERC725Y data keys.
 
 ## Motivation
 
@@ -28,7 +28,7 @@ A schema defines a blueprint for how a data store is constructed.
 
 In the context of smart contracts, it can offer a better view of how the data is organised and structured within the contract storage.
 
-Using a standardised schema over ERC725Y enables those keys and values to be easily readable and automatically parsable. Contracts and interfaces can know how to read and interact with the storage of an ERC725Y smart contract.
+Using a standardised schema over ERC725Y enables those data keys and values to be easily readable and automatically parsable. Contracts and interfaces can know how to read and interact with the storage of an ERC725Y smart contract.
 
 The advantage of such schema is to allow interfaces or smart contracts to better decode (read, parse and interpret) the data stored in an ERC725Y contract. It is less error-prone due to knowing data types upfront. On the other hand, it also enables interfaces and contracts to know how to correctly encode data, before being set on an ERC725Y contract.
 
@@ -39,7 +39,7 @@ This schema is for example used in [ERC725](https://github.com/ethereum/EIPs/blo
 
 > **Note:** described sets might not yet be complete, as they could be extended over time.
 
-To make ERC725Y keys readable, we describe a key-value pair as a JSON object containing the following entries:
+To make ERC725Y data keys readable, we describe a data key-value pair as a JSON object containing the following entries:
 
 ```json
 {
@@ -55,36 +55,36 @@ The table below describes each entries with their available options.
 
 | Title | Description |
 |:----|:----|
-|[`name`](#name)| the name of the key |
-|[`key`](#key)| the **unique identifier** of the key |
-|[`keyType`](#keyType)| *How* the key must be treated <hr> [`Singleton`](#Singleton) <br> [`Array`](#Array) <br> [`Mapping`](#Mapping) <br> [`Bytes20Mapping`](#Bytes20Mapping) <br> [`Bytes20MappingWithGrouping`](#Bytes20MappingWithGrouping) |
+|[`name`](#name)| the name of the data key |
+|[`key`](#key)| the **unique identifier** of the data key |
+|[`keyType`](#keyType)| *How* the data key must be treated <hr> [`Singleton`](#Singleton) <br> [`Array`](#Array) <br> [`Mapping`](#Mapping) <br> [`Bytes20Mapping`](#Bytes20Mapping) <br> [`Bytes20MappingWithGrouping`](#Bytes20MappingWithGrouping) |
 |[`valueType`](#valueType)| *How* a value MUST be decoded <hr> `boolean` <br> `string` <br> `address` <br> `uintN` <br> `intN` <br> `bytesN` <br> `bytes` <br> `uintN[]` <br> `intN[]` <br> `string[]` <br> `address[]` <br> `bytes[]` |
 |[`valueContent`](#valueContent)| *How* a value SHOULD be interpreted <hr> `Boolean` <br> `String` <br> `Address` <br> `Number` <br> `BytesN` <br> `Bytes` <br> `Keccak256` <br> [`BitArray`](#BitArray) <br> `URL` <br> [`AssetURL`](#AssetURL) <br> [`JSONURL`](#JSONURL) <br> `Markdown` <br> `Literal` (*e.g.:* `0x1345ABCD...`) |
 
 ### `name`
 
-The `name` is the human-readable format of the ERC725Y key. It aims to abstract the representation of the ERC725Y key and defines what the key represents. In most cases, it SHOULD highlight the intent behind the key.
+The `name` is the human-readable format of the ERC725Y data key. It aims to abstract the representation of the ERC725Y data key and defines what the data key represents. In most cases, it SHOULD highlight the intent behind the data key.
 
-In scenarios where an ERC725Y key is part of an LSP Standard, the key `name` SHOULD be comprised of the following: `LSP{N}{KeyName}`, where
+In scenarios where an ERC725Y data key is part of an LSP Standard, the data key `name` SHOULD be comprised of the following: `LSP{N}{KeyName}`, where
 
 - `LSP`: abbreviation for **L**UKSO **S**tandards **P**roposal.
-- `N`: the **Standard Number** this key refers to.
-- `KeyName`: base of the key name. Should represent the meaning of a value stored behind the key.
+- `N`: the **Standard Number** this data key refers to.
+- `KeyName`: base of the data key name. Should represent the meaning of a value stored behind the data key.
 
 *e.g.:* `MyColourTheme` (not part of any LSP Standard), `LSP4TokenName` (part of a LSP standard)
 
 
 ### `key`
 
-The `key` is a `bytes32` value that acts as the **unique identifier** for the key. It is the actual key that MUST be used to retrieve the value stored in the contract storage, via `ERC725Y.getData(bytes32 key)`.
+The `key` is a `bytes32` value that acts as the **unique identifier** for the data key. It is the actual data key that MUST be used to retrieve the value stored in the contract storage, via `ERC725Y.getData(bytes32 dataKey)`.
 
 The standard `keccak256` hashing algorithm is used to generate this identifier. However, *how* the identifier is constructed varies, depending on the `keyType`:
 
-- for `Singleton` keys: the hash of the key name (*e.g.:* `keccak256('MyKeyName') = 0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2`)
-- for `Array` keys (see [`Array`](#array) section for more details), **a combination of:**
-  - an initial key containing the array length.
-  - subsequent keys for array index access.
-- for mapping keys, see each mapping type separately below.
+- for `Singleton` data keys: the hash of the data key name (*e.g.:* `keccak256('MyKeyName') = 0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2`)
+- for `Array` data keys (see [`Array`](#array) section for more details), **a combination of:**
+  - an initial data key containing the array length.
+  - subsequent data keys for array index access.
+- for mapping data keys, see each mapping type separately below.
 
 
 ### `keyType`
@@ -93,16 +93,16 @@ The `keyType` determines how the value(s) should be interpreted.
 
 | `keyType` | Description  | Example |
 |---|---|---|
-| [`Singleton`](#singleton)  | A simple key  | `bytes32(keccak256("MyKeyName"))`<br> --- <br> `MyKeyName` -->  `0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2` |
-| [`Array`](#array)  | an array spanning multiple ERC725Y keys  | `bytes32(keccak256("MyKeyName[]"))` <br> --- <br> `MyKeyName[]` -->   `0x24f6297f3abd5a8b82f1a48cee167cdecef40aa98fbf14534ea3539f66ca834c`|
-| [`Mapping`](#mapping)  | a key that map two words  | `bytes16(keccak256("MyKeyName"))` + `bytes12(0)` + `bytes4(keccak256("MapName"))` <br> --- <br> `MyKeyName:MapName` -->  `0x24f6297f3abd5a8b82f1a48cee167cde000000000000000000000000e6041813` |
-| [`Bytes20Mapping`](#bytes20mapping)  | a key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` | `bytes8(keccak256("MyKeyName"))` + `bytes4(0)` +  `bytes20(dynamicValue)` <br> --- <br> `MyKeyName:cafecafecafecafecafecafecafecafecafecafe` -->  `0x35e6950bc8d21a1600000000cafecafecafecafecafecafecafecafecafecafe` |
-| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  | `bytes4(keccak256("MyKeyName"))` + `bytes4(0)` + `bytes2(keccak256("MapName"))` + `bytes2(0)` +  `bytes20(dynamicValue)` <br> --- <br> `MyKeyName:MapName:cafecafecafecafecafecafecafecafecafecafe` -->  `0x35e6950b00000000e6040000cafecafecafecafecafecafecafecafecafecafe` |
+| [`Singleton`](#singleton)  | A simple data key  | `bytes32(keccak256("MyKeyName"))`<br> --- <br> `MyKeyName` -->  `0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2` |
+| [`Array`](#array)  | an array spanning multiple ERC725Y data keys  | `bytes32(keccak256("MyKeyName[]"))` <br> --- <br> `MyKeyName[]` -->   `0x24f6297f3abd5a8b82f1a48cee167cdecef40aa98fbf14534ea3539f66ca834c`|
+| [`Mapping`](#mapping)  | a data key that map two words  | `bytes16(keccak256("MyKeyName"))` + `bytes12(0)` + `bytes4(keccak256("MapName"))` <br> --- <br> `MyKeyName:MapName` -->  `0x24f6297f3abd5a8b82f1a48cee167cde000000000000000000000000e6041813` |
+| [`Bytes20Mapping`](#bytes20mapping)  | a data key that maps a word to a `bytes20` value, such as (but not restricted to) an `address` | `bytes8(keccak256("MyKeyName"))` + `bytes4(0)` +  `bytes20(dynamicValue)` <br> --- <br> `MyKeyName:cafecafecafecafecafecafecafecafecafecafe` -->  `0x35e6950bc8d21a1600000000cafecafecafecafecafecafecafecafecafecafe` |
+| [`Bytes20MappingWithGrouping`](#bytes20mappingwithgrouping)  | a data key that maps a word to another word to a `bytes20` value, such as (but not restricted to) an `address`  | `bytes4(keccak256("MyKeyName"))` + `bytes4(0)` + `bytes2(keccak256("MapName"))` + `bytes2(0)` +  `bytes20(dynamicValue)` <br> --- <br> `MyKeyName:MapName:cafecafecafecafecafecafecafecafecafecafe` -->  `0x35e6950b00000000e6040000cafecafecafecafecafecafecafecafecafecafe` |
 
 
 ### `valueType`
 
-Describes the underlying data type of a value stored under a specific ERC725Y key. It refers to the type for the smart contract language like [Solidity](https://docs.soliditylang.org).
+Describes the underlying data type of a value stored under a specific ERC725Y data key. It refers to the type for the smart contract language like [Solidity](https://docs.soliditylang.org).
 
 The `valueType` is relevant for interfaces to know how a value MUST be encoded/decoded. This include:
 
@@ -158,9 +158,9 @@ Valid `valueContent` are:
 
 ### Singleton
 
-A **Singleton** key refers to a simple key. It is constructed using `bytes32(keccak256("KeyName"))`,
+A **Singleton** data key refers to a simple data key. It is constructed using `bytes32(keccak256("KeyName"))`,
 
-Below is an example of a Singleton key type:
+Below is an example of a Singleton data key type:
 
 ```json
 {
@@ -183,24 +183,24 @@ An array of elements, where each element has the same `valueType`.
 
 **Requirements:**
 
-A key of **Array** type MUST have the following requirements:
+A data key of **Array** type MUST have the following requirements:
 
-- The `name` of the key MUST have a `[]` (square brackets).
-- The `key` itself MUST be the keccak256 hash digest of the **full key `name`, including the square brackets `[]`**
-- The value stored under the full key hash MUST contain the total number of elements (= array length). It MUST be updated every time a new element is added to the array.
-- The value stored under the full key hash **MUST be stored as `uint256`** (32 bytes long, padded left with leading zeros).
+- The `name` of the data key MUST have a `[]` (square brackets).
+- The `key` itself MUST be the keccak256 hash digest of the **full data key `name`, including the square brackets `[]`**
+- The value stored under the full data key hash MUST contain the total number of elements (= array length). It MUST be updated every time a new element is added to the array.
+- The value stored under the full data key hash **MUST be stored as `uint256`** (32 bytes long, padded left with leading zeros).
 
 **Construction:**
 
 For the **Array** `keyType`, the initial `key` contains the total number of elements stored in the Array (= array length). It is constructed using `bytes32(keccak256(KeyName))`.
 
 Each Array element can be accessed through its own `key`. The `key` of an Array element consists of `bytes16(keccak256(KeyName)) + bytes16(uint128(ArrayElementIndex))`, where:
-- `bytes16(keccak256(KeyName))` = The first 16 bytes are the keccak256 hash of the full Array key `name` (including the `[]`) (e.g.: `LSP3IssuedAssets[]`)
+- `bytes16(keccak256(KeyName))` = The first 16 bytes are the keccak256 hash of the full Array data key `name` (including the `[]`) (e.g.: `LSP3IssuedAssets[]`)
 - `bytes16(uint128(ArrayElementIndex))` = the position (= index) of the element in the array (**NB**: elements index access start at `0`)
 
 *example:*
 
-Below is an example for the **Array** key named `LSP3IssuedAssets[]`.
+Below is an example for the **Array** data key named `LSP3IssuedAssets[]`.
 
 - total number of elements: 
   - key: `0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0`, 
@@ -236,7 +236,7 @@ value: 0xcafecafecafecafecafecafecafecafecafecafe
 
 ### Mapping
 
-A **Mapping** key is constructed using `bytes16(keccak256("FirstWord")) + bytes12(0) + bytes4(keccak256("SecondWord"))`.  
+A **Mapping** data key is constructed using `bytes16(keccak256("FirstWord")) + bytes12(0) + bytes4(keccak256("SecondWord"))`.  
 
 *example:*
 
@@ -257,9 +257,9 @@ A **Mapping** key is constructed using `bytes16(keccak256("FirstWord")) + bytes1
 
 ### Bytes20Mapping
 
-**Bytes20Mapping** could be used to map words to `bytes20` long data, such as `addresses`. Such key type can be useful when the second word in the mapping is too long and makes the key greater than 32 bytes.
+**Bytes20Mapping** could be used to map words to `bytes20` long data, such as `addresses`. Such key type can be useful when the second word in the mapping is too long and makes the data key greater than 32 bytes.
 
-A **Bytes20Mapping** mapping key is constructed using `bytes8(keccak256(FirstWord)) + bytes4(0) + bytes20(address)`.
+A **Bytes20Mapping** mapping data key is constructed using `bytes8(keccak256(FirstWord)) + bytes4(0) + bytes20(address)`.
 
 *e.g.:* `MyCoolAddress:<address>` > `0x22496f48a493035f 00000000 cafecafecafecafecafecafecafecafecafecafe`
 
@@ -275,12 +275,12 @@ A **Bytes20Mapping** mapping key is constructed using `bytes8(keccak256(FirstWor
 
 ### Bytes20MappingWithGrouping
 
-A **Bytes20MappingWithGrouping** key could be used to map two words to addresses, or other bytes 20 long data.
-This key is constructed using `bytes4(keccak256(FirstWord)) + bytes4(0) + bytes2(keccak256(SecondWord)) + bytes2(0) + bytes20(address)`,     
+A **Bytes20MappingWithGrouping** data key could be used to map two words to addresses, or other bytes 20 long data.
+This data key is constructed using `bytes4(keccak256(FirstWord)) + bytes4(0) + bytes2(keccak256(SecondWord)) + bytes2(0) + bytes20(address)`,     
 
 e.g. `AddressPermissions:Permissions:<address>` > `0x4b80742d 00000000 eced 0000 cafecafecafecafecafecafecafecafecafecafe`.
 
-Below is an example of a mapping key type:
+Below is an example of a mapping data key type:
 
 ```json
 {
@@ -314,11 +314,11 @@ The example shows how a `BitArray` value can be read and interpreted.
 }
 ```
 
-As the key `name` suggests, it defines a list of (user-defined) permissions, where each permission maps to a single bit at position `n`.
+As the data key `name` suggests, it defines a list of (user-defined) permissions, where each permission maps to a single bit at position `n`.
 - When a bit at position `n` is set (`1`), the permission defined at position `n` will be set.
 - When a bit at position `n` is not set (`0`), the permission defined at position `n` will not be set.
 
-Since the `valueType` is of type `bytes1`, this key can hold 8 user-defined permissions.
+Since the `valueType` is of type `bytes1`, this data key can hold 8 user-defined permissions.
 
 For instance, for the following permissions:
 
@@ -349,7 +349,7 @@ Setting multiple permissions like `TRANSFER VALUE + CALL + SET DATA` will result
 |:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
 | `0` | `1` | `0` | `0` | `0` | `1` | `1` | `0` |
 
-The idea is to always read the value of a **BitArray** key as binary digits, while its content is always written as a `bytes1` (in hex) in the ERC725Y contract storage.
+The idea is to always read the value of a **BitArray** data key as binary digits, while its content is always written as a `bytes1` (in hex) in the ERC725Y contract storage.
 
 ### AssetURL
 
@@ -475,13 +475,13 @@ if(hashFunction === '0x6f357c6a') {
 
 ## Rationale
 
-The structure of the key value layout as JSON allows interfaces to auto decode these key values as they will know how to decode them.
+The structure of the data key value layout as JSON allows interfaces to auto decode these data key values as they will know how to decode them.
 
 ## Implementation
 
-Below is an example of an ERC725Y JSON Schema containing 3 x ERC725Y keys.
+Below is an example of an ERC725Y JSON Schema containing 3 x ERC725Y data keys.
 
-Using such schema allows interfaces to auto decode and interpret the values retrieved from the ERC725Y key-value store.
+Using such schema allows interfaces to auto decode and interpret the values retrieved from the ERC725Y data key-value store.
 
 ```json
 [

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -16,7 +16,7 @@ This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob
  
 ## Abstract
 
-This standard, defines a set of key value stores that are useful to create a public on-chain profile, based on an [ERC725Account](./LSP-0-ERC725Account.md).
+This standard, defines a set of data key value stores that are useful to create a public on-chain profile, based on an [ERC725Account](./LSP-0-ERC725Account.md).
 
 ## Motivation
 
@@ -24,9 +24,9 @@ This standard describes meta data that can be added to an [ERC725Account](https:
 
 ## Specification
 
-Every contract that supports the Universal Profile standard SHOULD add the following [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) keys:
+Every contract that supports the Universal Profile standard SHOULD add the following [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) data keys:
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
 
 #### SupportedStandards:LSP3UniversalProfile

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -16,7 +16,7 @@ This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob
  
 ## Abstract
 
-This standard, defines a set of data key value stores that are useful to create a public on-chain profile, based on an [ERC725Account](./LSP-0-ERC725Account.md).
+This standard, defines a set of data key-value pairs that are useful to create a public on-chain profile, based on an [ERC725Account](./LSP-0-ERC725Account.md).
 
 ## Motivation
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -11,7 +11,7 @@ requires: ERC725Y, LSP2
  
 ## Simple Summary
 
-This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) data key value stores that describe a digital asset.
+This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) data key-value pairs that describe a digital asset.
 
 ## Abstract
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -11,11 +11,11 @@ requires: ERC725Y, LSP2
  
 ## Simple Summary
 
-This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key value stores that describe a digital asset.
+This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) data key value stores that describe a digital asset.
 
 ## Abstract
 
-This standard, defines a set of key-value pairs that are useful to describe a digital asset.
+This standard, defines a set of data key-value pairs that are useful to describe a digital asset.
 
 ## Motivation
 
@@ -23,12 +23,12 @@ This standard aims to create a better version of tokens and NFTs to allow more f
 As NFTs mostly have a creator, those creators should be able to improve the assets (link better 3D files, as 3D file standards improve), or change attributes.
 One could even think of a smart contract system that can increase attributes based on certain inputs automatically.
 
-An LSP4 Digital Asset is controlled by a single `owner`, expected to be a [ERC725](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md) smart contract. This owner is able to [`setData(...)`](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#setdata), and therefore change values of keys, and can potentially mint new items.
+An LSP4 Digital Asset is controlled by a single `owner`, expected to be a [ERC725](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md) smart contract. This owner is able to [`setData(...)`](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#setdata), and therefore change values of data keys, and can potentially mint new items.
  
 
 ## Specification
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
 #### SupportedStandards:LSP4DigitalAsset
 

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -10,27 +10,27 @@ requires: LSP2
 ---
 
 ## Simple Summary
-This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) key values to store addresses of received assets in a [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
+This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) data key values to store addresses of received assets in a [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
 
 ## Abstract
-This key value standard describes a set of keys that can be added to an [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
-Two keys are proposed to reference received asset smart contracts.
+This data key value standard describes a set of data keys that can be added to an [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
+Two data keys are proposed to reference received asset smart contracts.
 
 - `LSP5ReceivedAssets[]` to hold an array of addresses.
 - `LSP5ReceivedAssetsMap` to hold:
   - the index in the former array where the received asset address is stored.
   - an [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) to easily identify the standard used by each asset smart contracts, without the need to query the contracts directly. 
 
-The key `LSP5ReceivedAssetsMap` also helps to prevent duplicates from being added to the array, when automatically added via smart contract (e.g. via an [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
+The data key `LSP5ReceivedAssetsMap` also helps to prevent duplicates from being added to the array, when automatically added via smart contract (e.g. via an [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
 
 ## Motivation
 To be able to display received assets in a profile we need to keep track of all received asset contract addresses. This is important for [UniversalProfile](./LSP-3-UniversalProfile-Metadata.md), but also [Vault](./LSP-9-Vault.md) smart contracts.
 
 ## Specification
 
-Every contract that supports the ERC725Account SHOULD have the following keys:
+Every contract that supports the ERC725Account SHOULD have the following data keys:
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
 
 #### LSP5ReceivedAssets[]

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -14,7 +14,6 @@ requires: ERC165, ERC1271, LSP2
 
 This standard describes a `KeyManager` contract with a set of pre-defined permissions for addresses. A KeyManager contract can control an [ERC725Account](./LSP-0-ERC725Account.md) like account, or any other [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) smart contract.
 
-
 ## Abstract
 
 This standard allows for controlling addresses to be restricted through multiple permissions, to act on and through this KeyManager on a controlled smart contract (for example an [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md)).
@@ -23,7 +22,7 @@ The KeyManager functions as a gateway for the [ERC725Account](./LSP-0-ERC725Acco
 
 Permissions are described in the [Permissions values section](#permission-values-in-addresspermissionspermissionsaddress). Furthermore addresses can be restricted to only talk to certain other smart contracts or address, specific functions or smart contracts supporting only specifc standard interfaces.
 
-The Permissions are stored at [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) ERC725Y key value store, and can therefore survive an upgrade to a new KeyManager contract.
+The Permissions are stored at [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) ERC725Y data key value store, and can therefore survive an upgrade to a new KeyManager contract.
 
 The flow of a transactions is as follows:
 
@@ -42,12 +41,12 @@ Storing the permissions at the core [ERC725Account](./LSP-0-ERC725Account.md) it
 ## Specification
 
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
-**The permissions that the KeyManager reads, are stored on the controlled-contracts ERC725Y key value store (for example an [ERC725Account](./LSP-0-ERC725Account.md))**
+**The permissions that the KeyManager reads, are stored on the controlled-contracts ERC725Y data key value store (for example an [ERC725Account](./LSP-0-ERC725Account.md))**
 
-The following ERC725Y keys are used to read permissions of certain addresses.
-These keys are based on the [LSP2-ERC725YJSONSchema](./LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[Bytes20MappingWithGrouping](./LSP-2-ERC725YJSONSchema.md#bytes20mappingwithgrouping)**
+The following ERC725Y data keys are used to read permissions of certain addresses.
+These data keys are based on the [LSP2-ERC725YJSONSchema](./LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[Bytes20MappingWithGrouping](./LSP-2-ERC725YJSONSchema.md#bytes20mappingwithgrouping)**
 
 
 #### AddressPermissions[]
@@ -69,9 +68,9 @@ For more informations about how to access each index of the `AddressPermissions[
 
 #### AddressPermissions:Permissions:\<address\>
 
-Contains a set of permissions for an address. Permissions defines what an address **can do on** an ERC725Account (*eg: edit the key-value store via SETDATA*), or **can perform on behalf of** the ERC725Account.
+Contains a set of permissions for an address. Permissions defines what an address **can do on** an ERC725Account (*eg: edit the data key-value store via SETDATA*), or **can perform on behalf of** the ERC725Account.
 
-Since the `valueType` of this key is `bytes32`, up to 255 different permissions can be defined. This includes the [ten default permissions](#permission-values-in-addresspermissionspermissionsaddress) defined below. Custom permissions can be defined on top of the default one (starting at `0x0000...0400` (`1024` in decimals)).
+Since the `valueType` of this data key is `bytes32`, up to 255 different permissions can be defined. This includes the [ten default permissions](#permission-values-in-addresspermissionspermissionsaddress) defined below. Custom permissions can be defined on top of the default one (starting at `0x0000...0400` (`1024` in decimals)).
 
 ```json
 {
@@ -132,9 +131,9 @@ Contains an array of bytes4 [ERC165 interface Ids](https://eips.ethereum.org/EIP
 
 #### AddressPermissions:AllowedERC725YKeys:\<address\>
 
-Contains an array of `bytes32` ERC725Y keys.
+Contains an array of `bytes32` ERC725Y data keys.
 
-This key can be used in combination with the `SETDATA` [permission](#permission-values-in-addresspermissionspermissionsaddress). It enables to restrict which keys an `address` can set or edit on the controlled ERC725Account, by providing an [abi encoded](https://docs.soliditylang.org/en/v0.8.11/units-and-global-variables.html#abi-encoding-and-decoding-functions)) array of ERC725Y keys.
+This data key can be used in combination with the `SETDATA` [permission](#permission-values-in-addresspermissionspermissionsaddress). It enables to restrict which data keys an `address` can set or edit on the controlled ERC725Account, by providing an [abi encoded](https://docs.soliditylang.org/en/v0.8.11/units-and-global-variables.html#abi-encoding-and-decoding-functions)) array of ERC725Y data keys.
 
 ```json
 {
@@ -146,9 +145,9 @@ This key can be used in combination with the `SETDATA` [permission](#permission-
 }
 ```
 
-Each key defined in the array MUST be 32 bytes long. It is possible to set a range of allowed ERC725Y keys (**= partial keys**), by setting:
-- some part of the keys as the exact key bytes
-- the rest of the key bytes as 0 bytes.
+Each data key defined in the array MUST be 32 bytes long. It is possible to set a range of allowed ERC725Y data keys (**= partial data keys**), by setting:
+- some part of the data keys as the exact data key bytes
+- the rest of the data key bytes as 0 bytes.
 
 The 0 bytes part will represent a part that is dynamic. Below is an example based on a [LSP2 Mapping](./LSP-2-ERC725YJSONSchema.md#Mapping) key type, where first word = `SupportedStandards`, and second word = `LSP3UniversalProfile`.
 
@@ -157,11 +156,11 @@ name: "SupportedStandards:LSP3UniversalProfile"
 key: 0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6
 ```
 
-By setting the value to `0xeafec4d89fa9619884b6b8913562645500000000000000000000000000000000` in the list of allowed ERC725Y key, one address can set any key **starting with the first word `SupportedStandards:...`**.
+By setting the value to `0xeafec4d89fa9619884b6b8913562645500000000000000000000000000000000` in the list of allowed ERC725Y data key, one address can set any data key **starting with the first word `SupportedStandards:...`**.
 
 ### Permission Values in AddressPermissions:Permissions:\<address\>
 
-The following permissions are allowed in the BitArray of the `AddressPermissions:Permissions:<address>` key for an address. The order can not be changed:
+The following permissions are allowed in the BitArray of the `AddressPermissions:Permissions:<address>` data key for an address. The order can not be changed:
 
 ```js
 CHANGEOWNER        = 0x0000000000000000000000000000000000000000000000000000000000000001;   // 0000 0000 0000 0001 // Allows changing the owner of the controlled contract

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -22,7 +22,7 @@ The KeyManager functions as a gateway for the [ERC725Account](./LSP-0-ERC725Acco
 
 Permissions are described in the [Permissions values section](#permission-values-in-addresspermissionspermissionsaddress). Furthermore addresses can be restricted to only talk to certain other smart contracts or address, specific functions or smart contracts supporting only specifc standard interfaces.
 
-The Permissions are stored at [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md) ERC725Y data key value store, and can therefore survive an upgrade to a new KeyManager contract.
+The Permissions are stored under the ERC725Y data key-value store of the linked [ERC725Account](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md), and can therefore survive an upgrade to a new KeyManager contract.
 
 The flow of a transactions is as follows:
 
@@ -156,7 +156,7 @@ name: "SupportedStandards:LSP3UniversalProfile"
 key: 0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6
 ```
 
-By setting the value to `0xeafec4d89fa9619884b6b8913562645500000000000000000000000000000000` in the list of allowed ERC725Y data key, one address can set any data key **starting with the first word `SupportedStandards:...`**.
+By setting the value to `0xeafec4d89fa9619884b6b8913562645500000000000000000000000000000000` in the list of allowed ERC725Y data keys, one address can set any data key **starting with the first word `SupportedStandards:...`**.
 
 ### Permission Values in AddressPermissions:Permissions:\<address\>
 

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -29,9 +29,9 @@ A commonality with [LSP8 IdentifiableDigitalAsset][LSP8] is desired so that the 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wikwi/wiki/Clients)).-->
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
-This standard expects the keys from [LSP4 DigitalAsset-Metadata][LSP4#erc725ykeys].
+This standard expects the data keys from [LSP4 DigitalAsset-Metadata][LSP4#erc725ykeys].
 
 ### Methods
 
@@ -245,16 +245,16 @@ interface ILSP7 is /* IERC165 */ {
 
     // ERC725Y
 
-    event DataChanged(bytes32 indexed key, bytes value);
+    event DataChanged(bytes32 indexed dataKey, bytes value);
 
 
-    function getData(bytes32 key) external view returns (bytes memory value);
+    function getData(bytes32 dataKey) external view returns (bytes memory value);
     
-    function setData(bytes32 key, bytes memory value) external; // onlyOwner
+    function setData(bytes32 dataKey, bytes memory value) external; // onlyOwner
 
-    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory values);
 
-    function setData(bytes32[] memory keys, bytes[] memory values) external; // onlyOwner
+    function setData(bytes32[] memory dataKeys, bytes[] memory values) external; // onlyOwner
 
 
     // LSP7

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -19,7 +19,7 @@ A standard interface for identifiable digital assets, allowing for tokens to be 
 <!--A short (~200 word) description of the technical issue being addressed.-->
 This standard defines an interface for tokens that are identified with a `tokenId`, based on [ERC721][ERC721]. A `bytes32` value is used for `tokenId` to allow many uses of token identification including numbers, contract addresses, and hashed values (ie. serial numbers).
 
-This standard defines a set of key value stores that are useful to know what the `tokenId` represents, and metadata for each `tokenId`.
+This standard defines a set of data key value stores that are useful to know what the `tokenId` represents, and metadata for each `tokenId`.
 
 ## Motivation
 <!--The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
@@ -31,11 +31,11 @@ A commonality with [LSP7 DigitalAsset][LSP7] is desired so that the two token im
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wikwi/wiki/Clients)).-->
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
-These are the expected keys for the LSP8 contract which mints tokens.
+These are the expected data keys for the LSP8 contract which mints tokens.
 
-This standard expects the keys from [LSP4 DigitalAsset-Metadata.][LSP4#erc725ykeys].
+This standard expects the data keys from [LSP4 DigitalAsset-Metadata.][LSP4#erc725ykeys].
 
 #### LSP8TokenIdType
 
@@ -75,7 +75,7 @@ When a metadata contract is created for a tokenId, the address COULD be stored i
 }
 ```
 
-For construction of the Bytes20Mapping key see: [LSP2 ERC725Y JSON Schema][LSP2#bytes20mapping]
+For construction of the Bytes20Mapping data key see: [LSP2 ERC725Y JSON Schema][LSP2#bytes20mapping]
 
 #### LSP8MetadataJSON:TokenId
 
@@ -90,11 +90,11 @@ When metadata JSON is created for a tokenId, the URL COULD be stored in the mint
     "valueContent": "JSONURL"
 }
 ```
-For construction of the Bytes20Mapping key see: [LSP2 ERC725Y JSON Schema][LSP2#bytes20mapping]
+For construction of the Bytes20Mapping data key see: [LSP2 ERC725Y JSON Schema][LSP2#bytes20mapping]
 For construction of the JSONURL value see: [LSP2 ERC725Y JSON Schema][LSP2#jsonurl]
 
 ---
-(TODO: discussion if there are other keys to include in the standard for the contract which mints tokens)
+(TODO: discussion if there are other data keys to include in the standard for the contract which mints tokens)
 ---
 
 
@@ -127,10 +127,10 @@ The `bytes32` of the `tokenId` this metadata is for, to be stored in the [ERC725
 ```
 
 ---
-(TODO: discussion if there are other TokenIdMetadata keys to include in the standard)
+(TODO: discussion if there are other TokenIdMetadata data keys to include in the standard)
 ---
 
-### ERC725Y keys for off-chain tokenId metadata
+### ERC725Y Data keys for off-chain tokenId metadata
 
 #### LSP8TokenIdMetadata
 
@@ -160,7 +160,7 @@ The linked JSON file SHOULD have the following format:
 ```
 
 ---
-(TODO: discussion if there are other TokenIdMetadata keys to include in the JSON document standard)
+(TODO: discussion if there are other TokenIdMetadata data keys to include in the JSON document standard)
 ---
 
 ### Methods
@@ -431,16 +431,16 @@ interface ILSP8 is /* IERC165 */ {
 
     // ERC725Y
 
-    event DataChanged(bytes32 indexed key, bytes value);
+    event DataChanged(bytes32 indexed dataKey, bytes value);
 
 
-    function getData(bytes32 key) external view returns (bytes memory value);
+    function getData(bytes32 dataKey) external view returns (bytes memory value);
     
-    function setData(bytes32 key, bytes memory value) external; // onlyOwner
+    function setData(bytes32 dataKey, bytes memory value) external; // onlyOwner
 
-    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory values);
 
-    function setData(bytes32[] memory keys, bytes[] memory values) external; // onlyOwner
+    function setData(bytes32[] memory dataKeys, bytes[] memory values) external; // onlyOwner
 
 
     // LSP8

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -19,7 +19,7 @@ A standard interface for identifiable digital assets, allowing for tokens to be 
 <!--A short (~200 word) description of the technical issue being addressed.-->
 This standard defines an interface for tokens that are identified with a `tokenId`, based on [ERC721][ERC721]. A `bytes32` value is used for `tokenId` to allow many uses of token identification including numbers, contract addresses, and hashed values (ie. serial numbers).
 
-This standard defines a set of data key value stores that are useful to know what the `tokenId` represents, and metadata for each `tokenId`.
+This standard defines a set of data-key value pairs that are useful to know what the `tokenId` represents, and the associated metadata for each `tokenId`.
 
 ## Motivation
 <!--The motivation is critical for LIPs that want to change the Lukso protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -67,7 +67,7 @@ MUST be emitted when a native token transfer was received.
 
 ## Rationale
 
-The ERC725 general data key value store allows for the ability to add any kind of information to the the contract, which allows future use cases. The general execution allows full interactebility with any smart contract or address. And the universal receiver allows the reaction to any future asset.
+The ERC725Y general data key value store allows for the ability to add any kind of information to the the contract, which allows future use cases. The general execution allows full interactability with any smart contract or address. And the universal receiver allows the reaction to any future asset.
 
 ## Implementation
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -31,13 +31,13 @@ _This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, to al
 
 Every contract that supports to the Vaults SHOULD implement:
 
-### ERC725Y Keys
+### ERC725Y Data Keys
 
 
 #### LSP1UniversalReceiverDelegate
 
 If the contract delegates its universal receiver to another smart contract,
-this smart contract address MUST be stored under the following key:
+this smart contract address MUST be stored under the following data key:
 
 ```json
 {
@@ -67,7 +67,7 @@ MUST be emitted when a native token transfer was received.
 
 ## Rationale
 
-The ERC725 general key value store allows for the ability to add any kind of information to the the contract, which allows future use cases. The general execution allows full interactebility with any smart contract or address. And the universal receiver allows the reaction to any future asset.
+The ERC725 general data key value store allows for the ability to add any kind of information to the the contract, which allows future use cases. The general execution allows full interactebility with any smart contract or address. And the universal receiver allows the reaction to any future asset.
 
 ## Implementation
 
@@ -112,20 +112,20 @@ interface ILSP9  /* is ERC165 */ {
         
     event ContractCreated(uint256 indexed _operation, address indexed contractAddress, uint256 indexed  _value);
     
-    event DataChanged(bytes32 indexed key, bytes value);
+    event DataChanged(bytes32 indexed dataKey, bytes value);
     
     
     function execute(uint256 operationType, address to, uint256 value, bytes memory data) external payable returns (bytes memory); // onlyOwner
 
-    function getData(bytes32 key) external view returns (bytes memory value);
+    function getData(bytes32 dataKey) external view returns (bytes memory value);
     
-    function setData(bytes32 key, bytes memory value) external; // onlyAllowed (UniversalReceiverDelegate and Owner)
+    function setData(bytes32 dataKey, bytes memory value) external; // onlyAllowed (UniversalReceiverDelegate and Owner)
     
-    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory values);
     
-    function setData(bytes32[] memory keys, bytes[] memory values) external; // onlyAllowed (UniversalReceiverDelegate and Owner)
+    function setData(bytes32[] memory dataKeys, bytes[] memory values) external; // onlyAllowed (UniversalReceiverDelegate and Owner)
         
-    // LSP0 possible keys:
+    // LSP0 possible data keys:
     // LSP1UniversalReceiverDelegate: 0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47
     
     // LSP1
@@ -134,7 +134,7 @@ interface ILSP9  /* is ERC165 */ {
 
     function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory);
     
-    // IF LSP1UniversalReceiverDelegate key is set
+    // IF LSP1UniversalReceiverDelegate data key is set
     // THEN calls will be forwarded to the address given (UniversalReceiver even MUST still be fired)
 }
 


### PR DESCRIPTION
## What does this PR introduce?
- Replacing the word `key` with `data keys` when referring to ERC725Y Keys.
This change excludes the **keywords** of all **LSP2ERC725YJSON**, example below:
```json
{
  "name": "LSP1UniversalReceiverDelegate",
  "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
  "keyType": "Singleton",
  "valueType": "address",
  "valueContent": "Address"
}
```
This is useful to distinguish between the normal keys (public/private keys) and the standardized ERC725Y keys (data keys).