### PR TITLE
docs(events): edit `Executed` event definition in LSP0, 6 and 9

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -126,7 +126,7 @@ interface ILSP0  /* is ERC165 */ {
     
     // ERC725X
 
-    event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed  _value, bytes _data);
+    event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed  _value, bytes4 _selector);
 
     event ContractCreated(uint256 indexed _operation, address indexed contractAddress, uint256 indexed  _value);
     

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -257,10 +257,12 @@ The final message MUST be signed using ethereum specific signature, based on [EI
 #### Executed
 
 ```solidity
-event Executed(uint256 indexed  _value, bytes _data);
+event Executed(uint256 indexed  _value, bytes4 _selector);
 ```
 
 MUST be fired when a transaction was successfully executed.
+
+The second parameter `_selector` in the `Executed` event corresponds to the `bytes4` selector of the function being executed in the linked [account](#account)
 
 
 ### What are multi-channel nonces
@@ -400,7 +402,7 @@ interface ILSP6  /* is ERC165 */ {
     
     // LSP6
         
-    event Executed(uint256 indexed  _value, bytes _data); 
+    event Executed(uint256 indexed  _value, bytes4 _selector); 
     
     
     function getNonce(address _address, uint256 _channel) external view returns (uint256);

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -108,7 +108,7 @@ interface ILSP9  /* is ERC165 */ {
     
     // ERC725
       
-    event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed  _value, bytes _data);
+    event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed  _value, bytes4 _selector);
         
     event ContractCreated(uint256 indexed _operation, address indexed contractAddress, uint256 indexed  _value);
     


### PR DESCRIPTION
# What does this PR introduce?

Edit `Executed` event definitions in LSP0, LSP6 and LSP9 to use only the first 4 bytes of the function selector and reflect changes in:

- https://github.com/ERC725Alliance/ERC725/pull/98
- https://github.com/lukso-network/lsp-smart-contracts/pull/143