### PR TITLE
Add Claim Ownership in LSP0 and LSP9

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -91,6 +91,8 @@ Allow an `address` to become the new owner of the contract.
 
 Only the pending owner MUST be allowed to claim ownership.
 
+MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event once the new owner has claimed ownership of the contract.
+
 
 ### Events
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -41,7 +41,9 @@ This allows us to:
 
 [ERC165] interface id: `0x9a3bfe88`
 
-_This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, ERC1271-isValidSignature, to allow detection of ERC725Accounts._
+_This interface id can be used to detect ERC725Account contracts._
+
+_This `bytes4` interface id is calculated as the XOR of the function selectors from the following interface standards: ERC725Y, ERC725X, LSP1-UniversalReceiver, ERC1271-isValidSignature and ClaimOwnership._
 
 Every contract that supports the LSP0 standard (ERC725Account) SHOULD implement:
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -68,6 +68,30 @@ this smart contract address MUST be stored under the following data key:
 Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor), [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification) and [LSP1](./LSP-1-UniversalReceiver.md#specification), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
+#### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address);
+```
+
+Return the `address` that ownership of the contract is being transferred to.
+
+MUST be set when transferring ownership of the contract to a new `address`.
+
+SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
+
+
+#### claimOwnership
+
+```
+function claimOwnership() external;
+```
+
+Allow an `address` to become the new owner of the contract.
+
+Only the pending owner MUST be allowed to claim ownership.
+
+
 ### Events
 
 #### ValueReceived
@@ -166,6 +190,13 @@ interface ILSP0  /* is ERC165 */ {
     
     // IF LSP1UniversalReceiverDelegate data key is set
     // THEN calls will be forwarded to the address given (UniversalReceiver even MUST still be fired)
+
+
+    // Claim Ownership
+    
+    function pendingOwner() external view returns (address);
+    
+    function claimOwnership() external;
 }
 
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -72,7 +72,7 @@ See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 Contains the methods from:
 - [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor)
 - [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification)
-- [LSP1](./LSP-1-UniversalReceiver.md#specification), 
+- [LSP1](./LSP-1-UniversalReceiver.md#specification)
 - Claim Ownership, a modified version of [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable). *See below for details*
 
 #### owner

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -39,7 +39,7 @@ This allows us to:
 
 ## Specification
 
-[ERC165] interface id: `0x481e0fe8`
+[ERC165] interface id: `0x9a3bfe88`
 
 _This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, ERC1271-isValidSignature, to allow detection of ERC725Accounts._
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -74,9 +74,9 @@ See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 function pendingOwner() external view returns (address);
 ```
 
-Return the `address` that ownership of the contract is being transferred to.
+Return the `address` of the pending owner, of a ownership transfer, that was initiated with `transferOwnership(address)`. MUST be `0x0000000000000000000000000000000000000000` if no ownership transfer is in progress.
 
-MUST be set when transferring ownership of the contract to a new `address`.
+MUST be set when transferring ownership of the contract via `transferOwnership(address)` to a new `address`.
 
 SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
 
@@ -87,9 +87,9 @@ SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership o
 function claimOwnership() external;
 ```
 
-Allow an `address` to become the new owner of the contract.
+Allow an `address` to become the new owner of the contract. MUST only be called by the pending owner.
 
-Only the pending owner MUST be allowed to claim ownership.
+MUST be called after `transferOwnership` by the current `pendingOwner` to finalize the ownership transfer.
 
 MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event once the new owner has claimed ownership of the contract.
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -65,8 +65,13 @@ this smart contract address MUST be stored under the following data key:
 
 ### Methods
 
-Contains the methods from [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor), [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification) and [LSP1](./LSP-1-UniversalReceiver.md#specification), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
+
+Contains the methods from:
+- [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor)
+- [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification)
+- [LSP1](./LSP-1-UniversalReceiver.md#specification), 
+- Claim Ownership, a modified version of [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable). *See below for details*
 
 #### owner
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -101,7 +101,7 @@ MUST set the `newOwner` as the `pendingOwner`.
 
 #### claimOwnership
 
-```
+```solidity
 function claimOwnership() external;
 ```
 
@@ -151,16 +151,21 @@ ERC725Y JSON Schema `ERC725Account`:
 interface ILSP0  /* is ERC165 */ {
          
     
-    // ERC173
+    // Modified ERC173 (ClaimOwnership)
     
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
 
     function owner() external view returns (address);
     
+    function pendingOwner() external view returns (address);
+
     function transferOwnership(address newOwner) external; // onlyOwner
 
+    function claimOwnership() external;
+    
     function renounceOwnership() external; // onlyOwner
+        
 
 
     // ERC1271
@@ -211,16 +216,6 @@ interface ILSP0  /* is ERC165 */ {
     // IF LSP1UniversalReceiverDelegate data key is set
     // THEN calls will be forwarded to the address given (UniversalReceiver even MUST still be fired)
 
-
-    // Claim Ownership
-
-    function owner() external view returns (address);
-    
-    function pendingOwner() external view returns (address);
-    
-    function transferOwnership(address newOwner) external;
-    
-    function claimOwnership() external;
 }
 
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -65,8 +65,16 @@ this smart contract address MUST be stored under the following data key:
 
 ### Methods
 
-Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor), [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification) and [LSP1](./LSP-1-UniversalReceiver.md#specification), 
+Contains the methods from [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor), [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification) and [LSP1](./LSP-1-UniversalReceiver.md#specification), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
+
+#### owner
+
+```solidity
+function owner() external view returns (address);
+```
+
+Returns the `address` of the current contract owner.
 
 #### pendingOwner
 
@@ -80,6 +88,16 @@ MUST be set when transferring ownership of the contract via `transferOwnership(a
 
 SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
 
+
+#### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external;
+```
+
+Transfers ownership of the contract to a `newOwner`.
+
+MUST set the `newOwner` as the `pendingOwner`.
 
 #### claimOwnership
 
@@ -195,8 +213,12 @@ interface ILSP0  /* is ERC165 */ {
 
 
     // Claim Ownership
+
+    function owner() external view returns (address);
     
     function pendingOwner() external view returns (address);
+    
+    function transferOwnership(address newOwner) external;
     
     function claimOwnership() external;
 }

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -51,9 +51,13 @@ this smart contract address MUST be stored under the following data key:
 
 ### Methods
 
-Contains the methods from [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) (General value and execution) and [LSP1](./LSP-1-UniversalReceiver.md), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
+Contains the methods from:
+- [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor)
+- [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification)
+- [LSP1](./LSP-1-UniversalReceiver.md#specification), 
+- Claim Ownership, a modified version of [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable). *See below for details*
 
 #### owner
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -61,9 +61,9 @@ See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 function pendingOwner() external view returns (address);
 ```
 
-Return the `address` that ownership of the contract is being transferred to.
+Return the `address` of the pending owner, of a ownership transfer, that was initiated with `transferOwnership(address)`. MUST be `0x0000000000000000000000000000000000000000` if no ownership transfer is in progress.
 
-MUST be set when transferring ownership of the contract to a new `address`.
+MUST be set when transferring ownership of the contract via `transferOwnership(address)` to a new `address`.
 
 SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
 
@@ -74,12 +74,11 @@ SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership o
 function claimOwnership() external;
 ```
 
-Allow an `address` to become the new owner of the contract.
+Allow an `address` to become the new owner of the contract. MUST only be called by the pending owner.
 
-Only the pending owner MUST be allowed to claim ownership.
+MUST be called after `transferOwnership` by the current `pendingOwner` to finalize the ownership transfer.
 
 MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event once the new owner has claimed ownership of the contract.
-
 
 ### Events
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -54,6 +54,33 @@ this smart contract address MUST be stored under the following data key:
 Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) (General value and execution) and [LSP1](./LSP-1-UniversalReceiver.md), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
+
+#### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address);
+```
+
+Return the `address` that ownership of the contract is being transferred to.
+
+MUST be set when transferring ownership of the contract to a new `address`.
+
+SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
+
+
+#### claimOwnership
+
+```
+function claimOwnership() external;
+```
+
+Allow an `address` to become the new owner of the contract.
+
+Only the pending owner MUST be allowed to claim ownership.
+
+MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event once the new owner has claimed ownership of the contract.
+
+
 ### Events
 
 #### ValueReceived
@@ -128,6 +155,7 @@ interface ILSP9  /* is ERC165 */ {
     // LSP0 possible data keys:
     // LSP1UniversalReceiverDelegate: 0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47
     
+    
     // LSP1
 
     event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
@@ -136,6 +164,13 @@ interface ILSP9  /* is ERC165 */ {
     
     // IF LSP1UniversalReceiverDelegate data key is set
     // THEN calls will be forwarded to the address given (UniversalReceiver even MUST still be fired)
+
+
+    // Claim Ownership
+
+    function pendingOwner() external view returns (address);
+    
+    function claimOwnership() external;
 }
 
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -25,7 +25,7 @@ This standard defines a vault that can hold assets and interact with other contr
 
 ## Specification
 
-[ERC165] interface id: `0x5e38b596`
+[ERC165] interface id: `0x8c1d44f6`
 
 _This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, to allow detection of Vaults._
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -27,7 +27,9 @@ This standard defines a vault that can hold assets and interact with other contr
 
 [ERC165] interface id: `0x8c1d44f6`
 
-_This interface id is the XOR of ERC725Y, ERC725X, LSP1-UniversalReceiver, to allow detection of Vaults._
+_This interface id can be used to detect Vault contracts._
+
+_This `bytes4` interface id is calculated as the XOR of the function selectors from the following interface standards: ERC725Y, ERC725X, LSP1-UniversalReceiver and ClaimOwnership._
 
 Every contract that supports the LSP9 standard SHOULD implement:
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -51,9 +51,17 @@ this smart contract address MUST be stored under the following data key:
 
 ### Methods
 
-Contains the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) (Ownable), [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) (General value and execution) and [LSP1](./LSP-1-UniversalReceiver.md), 
+Contains the methods from [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) (General value and execution) and [LSP1](./LSP-1-UniversalReceiver.md), 
 See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
+
+#### owner
+
+```solidity
+function owner() external view returns (address);
+```
+
+Returns the `address` of the current contract owner.
 
 #### pendingOwner
 
@@ -67,6 +75,16 @@ MUST be set when transferring ownership of the contract via `transferOwnership(a
 
 SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
 
+
+#### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external;
+```
+
+Transfers ownership of the contract to a `newOwner`.
+
+MUST set the `newOwner` as the `pendingOwner`.
 
 #### claimOwnership
 
@@ -167,7 +185,11 @@ interface ILSP9  /* is ERC165 */ {
 
     // Claim Ownership
 
+    function owner() external view returns (address);
+    
     function pendingOwner() external view returns (address);
+    
+    function transferOwnership(address newOwner) external;
     
     function claimOwnership() external;
 }

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -88,7 +88,7 @@ MUST set the `newOwner` as the `pendingOwner`.
 
 #### claimOwnership
 
-```
+```solidity
 function claimOwnership() external;
 ```
 
@@ -140,14 +140,22 @@ interface ILSP9  /* is ERC165 */ {
     event ValueReceived(address indexed sender, uint256 indexed value);
          
     
-    // ERC173
+    // Modified ERC173 (ClaimOwnership)
     
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
 
     function owner() external view returns (address);
     
+    function pendingOwner() external view returns (address);
+
     function transferOwnership(address newOwner) external; // onlyOwner
+
+    function claimOwnership() external;
+    
+    function renounceOwnership() external; // onlyOwner
+        
+
 
     
     // ERC725
@@ -182,16 +190,6 @@ interface ILSP9  /* is ERC165 */ {
     // IF LSP1UniversalReceiverDelegate data key is set
     // THEN calls will be forwarded to the address given (UniversalReceiver even MUST still be fired)
 
-
-    // Claim Ownership
-
-    function owner() external view returns (address);
-    
-    function pendingOwner() external view returns (address);
-    
-    function transferOwnership(address newOwner) external;
-    
-    function claimOwnership() external;
 }
 
 


### PR DESCRIPTION
# What does this PR introduce?

- [x] add `pendingOwner` and `claimOwnership` under **Methods** sections in LSP0 and LSP9
- [x] add `pendingOwner` and `claimOwnership` under **Interface Cheat Sheet** in LSP0 and LSP9