### PR TITLE
change `Bytes20Mapping` and `Bytes20MappingWithGrouping` keys schemas across LSPs

### DIFF
--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -59,8 +59,8 @@ Value example: `0x8c1d44f6000000000000000c` (interfaceId: `0x8c1d44f6`, index po
 ```json
 {
     "name": "LSP10VaultsMap:<address>",
-    "key": "0x192448c3c0f88c7f00000000<address>",
-    "keyType": "Bytes20Mapping",
+    "key": "0x192448c3c0f88c7f238c0000<address>",
+    "keyType": "Mapping",
     "valueContent": "Mixed",
     "valueType": "bytes"
 }
@@ -78,8 +78,8 @@ ERC725Y JSON Schema `LSP10ReceivedVaults`:
 [
     {
         "name": "LSP10VaultsMap:<address>",
-        "key": "0x192448c3c0f88c7f00000000<address>",
-        "keyType": "Bytes20Mapping",
+        "key": "0x192448c3c0f88c7f238c0000<address>",
+        "keyType": "Mapping",
         "valueContent": "Mixed",
         "valueType": "bytes"
     },

--- a/LSPs/LSP-12-IssuedAssets.md
+++ b/LSPs/LSP-12-IssuedAssets.md
@@ -68,8 +68,8 @@ Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index po
 ```json
 {
     "name": "LSP12IssuedAssetsMap:<address>",
-    "key": "0x74ac2555c10b934900000000<address>",
-    "keyType": "Bytes20Mapping",
+    "key": "0x74ac2555c10b9349e78f0000<address>",
+    "keyType": "Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"
 }
@@ -91,8 +91,8 @@ ERC725Y JSON Schema `LSP12IssuedAssets`:
     },
     {
         "name": "LSP12IssuedAssetsMap:<address>",
-        "key": "0x74ac2555c10b934900000000<address>",
-        "keyType": "Bytes20Mapping",
+        "key": "0x74ac2555c10b9349e78f0000<address>",
+        "keyType": "Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     }

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -285,7 +285,7 @@ A **MappingWithGrouping** data key is constructed using:
 - `bytes<M>` and `address` and static word hashes (`bytes32`) will be left padded, but right-cut, if its larger than the max bytes of that section.
 
 
-e.g. `AddressPermissions:Permissions:<address>` > `0x4b80742d 00000000 eced 0000 cafecafecafecafecafecafecafecafecafecafe`.
+e.g. `AddressPermissions:Permissions:<address>` > `0x4b80742de2bf 82acb363 0000 cafecafecafecafecafecafecafecafecafecafe`.
 
 *example:*
 ```js

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -210,8 +210,8 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
     },
     {
         "name": "LSP12IssuedAssetsMap:<address>",
-        "key": "0x74ac2555c10b934900000000<address>",
-        "keyType": "Bytes20Mapping",
+        "key": "0x74ac2555c10b9349e78f0000<address>",
+        "keyType": "Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     },
@@ -226,8 +226,8 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
     },
     {
         "name": "LSP5ReceivedAssetsMap:<address>",
-        "key": "0x812c4334633eb81600000000<address>",
-        "keyType": "Bytes20Mapping",
+        "key": "0x812c4334633eb816c80d0000<address>",
+        "keyType": "Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     },

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -201,12 +201,12 @@ For more informations about how to access each index of the `LSP4Creators[]` arr
 
 References the creator addresses for this asset.
 
-The `valueContent` MUST be constructed as follows: `bytes8(indexNumber) + bytes4(standardInterfaceId)`. 
+The `valueContent` MUST be constructed as follows: `bytes4(standardInterfaceId) + bytes8(indexNumber)`. 
 Where:
-- `indexNumber` = the index in the [`LSP4Creators[]` Array](##lsp4creators)
-- `standardInterfaceId` = if the creator address is a smart contract, the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the smart contract implements. Otherwise `0x00000000` in the case where the creator address is:
+- `standardInterfaceId` = if the creator address is a smart contract, the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the smart contract implements. Otherwise `0xffffffff` in the case where the creator address is:
   - an Externally Owned Account, or 
   - a contract implementing no ERC165 interface ID.
+- `indexNumber` = the index in the [`LSP4Creators[]` Array](##lsp4creators)
 
 ```json
 {

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -211,8 +211,8 @@ Where:
 ```json
 {
     "name": "LSP4CreatorsMap:<address>",
-    "key": "0x6de85eaf5d982b4e00000000<address>",
-    "keyType": "Bytes20Mapping",
+    "key": "0x6de85eaf5d982b4e5da00000<address>",
+    "keyType": "Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"
 }
@@ -261,8 +261,8 @@ ERC725Y JSON Schema `LSP4DigitalAsset`:
     },
     {
         "name": "LSP4CreatorsMap:<address>",
-        "key": "0x6de85eaf5d982b4e00000000<address>",
-        "keyType": "Bytes20Mapping",
+        "key": "0x6de85eaf5d982b4e5da00000<address>",
+        "keyType": "Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     },

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -59,8 +59,6 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 
 Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index position `0x000000000000000c = 16`).
 
-// 812c4334633eb816c80deebfa5fb7d2509eb438ca1b6418106442cb5ccc62f6c
-
 ```json
 {
     "name": "LSP5ReceivedAssetsMap:<address>",

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -59,11 +59,13 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 
 Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index position `0x000000000000000c = 16`).
 
+// 812c4334633eb816c80deebfa5fb7d2509eb438ca1b6418106442cb5ccc62f6c
+
 ```json
 {
     "name": "LSP5ReceivedAssetsMap:<address>",
-    "key": "0x812c4334633eb81600000000<address>",
-    "keyType": "Bytes20Mapping",
+    "key": "0x812c4334633eb816c80d0000<address>",
+    "keyType": "Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"
 }
@@ -80,8 +82,8 @@ ERC725Y JSON Schema `LSP5ReceivedAssets`:
 [
     {
         "name": "LSP5ReceivedAssetsMap:<address>",
-        "key": "0x812c4334633eb81600000000<address>",
-        "keyType": "Bytes20Mapping",
+        "key": "0x812c4334633eb816c80d0000<address>",
+        "keyType": "Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     },

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -50,7 +50,7 @@ Every contract that supports the LSP6 standard SHOULD implement:
 **The permissions that the KeyManager reads, are stored on the controlled-contracts ERC725Y data key value store (for example an [ERC725Account](./LSP-0-ERC725Account.md))**
 
 The following ERC725Y data keys are used to read permissions of certain addresses.
-These data keys are based on the [LSP2-ERC725YJSONSchema](./LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[Bytes20MappingWithGrouping](./LSP-2-ERC725YJSONSchema.md#bytes20mappingwithgrouping)**
+These data keys are based on the [LSP2-ERC725YJSONSchema](./LSP-2-ERC725YJSONSchema.md) standard, and use the key type **[`MappingWithGrouping`](./LSP-2-ERC725YJSONSchema.md#mappingwithgrouping)**
 
 
 #### AddressPermissions[]
@@ -79,8 +79,8 @@ Since the `valueType` of this data key is `bytes32`, up to 255 different permiss
 ```json
 {
     "name": "AddressPermissions:Permissions:<address>",
-    "key": "0x4b80742d0000000082ac0000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bf82acb3630000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "bytes32",
     "valueContent": "BitArray"
 }
@@ -96,8 +96,8 @@ Contains an array of addresses (Externally Owned Accounts or smart contracts) a 
 ```json
 {
     "name": "AddressPermissions:AllowedAddresses:<address>",
-    "key": "0x4b80742d00000000c6dd0000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bfc6dd6b3c0000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "address[]",
     "valueContent": "Address"
 }
@@ -112,8 +112,8 @@ This permission acts as a restriction mechanism when interacting with other smar
 ```json
 {
     "name": "AddressPermissions:AllowedFunctions:<address>",
-    "key": "0x4b80742d000000008efe0000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bf8efea1e80000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "bytes4[]",
     "valueContent": "Bytes4"
 }
@@ -126,8 +126,8 @@ Contains an array of bytes4 [ERC165 interface Ids](https://eips.ethereum.org/EIP
 ```json
 {
     "name": "AddressPermissions:AllowedStandards:<address>",
-    "key": "0x4b80742d000000003efa0000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bf3efa94a30000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "bytes4[]",
     "valueContent": "Bytes4"
 }
@@ -142,8 +142,8 @@ This data key can be used in combination with the `SETDATA` [permission](#permis
 ```json
 {
     "name": "AddressPermissions:AllowedERC725YKeys:<address>",
-    "key": "0x4b80742d0000000090b80000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bf90b8b4850000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "bytes32[]",
     "valueContent": "Bytes32"
 }
@@ -361,36 +361,36 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the `LSP3Account`:
     },
     {
         "name": "AddressPermissions:Permissions:<address>",
-        "key": "0x4b80742d0000000082ac0000<address>",
-        "keyType": "Bytes20MappingWithGrouping",
+        "key": "0x4b80742de2bf82acb3630000<address>",
+        "keyType": "MappingWithGrouping",
         "valueType": "bytes32",
         "valueContent": "BitArray"
     },
     {
         "name": "AddressPermissions:AllowedAddresses:<address>",
-        "key": "0x4b80742d00000000c6dd0000<address>",
-        "keyType": "Bytes20MappingWithGrouping",
+        "key": "0x4b80742de2bfc6dd6b3c0000<address>",
+        "keyType": "MappingWithGrouping",
         "valueType": "address[]",
         "valueContent": "Address"
     },
     {
         "name": "AddressPermissions:AllowedFunctions:<address>",
-        "key": "0x4b80742d000000008efe0000<address>",
-        "keyType": "Bytes20MappingWithGrouping",
+        "key": "0x4b80742de2bf8efea1e80000<address>",
+        "keyType": "MappingWithGrouping",
         "valueType": "bytes4[]",
         "valueContent": "Bytes4"
     },
     {
         "name": "AddressPermissions:AllowedStandards:<address>",
-        "key": "0x4b80742d000000003efa0000<address>",
-        "keyType": "Bytes20MappingWithGrouping",
+        "key": "0x4b80742de2bf3efa94a30000<address>",
+        "keyType": "MappingWithGrouping",
         "valueType": "bytes4[]",
         "valueContent": "Bytes4"
     },
     {
         "name": "AddressPermissions:AllowedERC725YKeys:<address>",
-        "key": "0x4b80742d0000000090b80000<address>",
-        "keyType": "Bytes20MappingWithGrouping",
+        "key": "0x4b80742de2bf90b8b4850000<address>",
+        "keyType": "MappingWithGrouping",
         "valueType": "bytes32[]",
         "valueContent": "Bytes32"
     }

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -65,7 +65,7 @@ This SHOULD not be changeable, and set only during initialization of the token.
 
 When a metadata contract is created for a tokenId, the address COULD be stored in the minting contract storage.
 
-For construction of the Mapping data key see: [LSP2 ERC725Y JSON Schema][LSP2#mapping]
+For construction of the Mapping data key see: [LSP2 ERC725Y JSON Schema > `keyType = Mapping`][LSP2#mapping]
 
 ```json
 {
@@ -81,8 +81,9 @@ For construction of the Mapping data key see: [LSP2 ERC725Y JSON Schema][LSP2#ma
 
 When metadata JSON is created for a tokenId, the URL COULD be stored in the minting contract storage.
 
-For construction of the Mapping data key see: [LSP2 ERC725Y JSON Schema][LSP2#mapping]
-For construction of the JSONURL value see: [LSP2 ERC725Y JSON Schema][LSP2#jsonurl]
+For construction of the Mapping data key see: [LSP2 ERC725Y JSON Schema > `keyType = Mapping`][LSP2#mapping]
+
+For construction of the JSONURL value see: [LSP2 ERC725Y JSON Schema > `valueContent = JSONURL`][LSP2#jsonurl]
 
 ```json
 {
@@ -147,7 +148,7 @@ The description of the asset.
 }
 ```
 
-For construction of the JSONURL value see: [LSP2 ERC725Y JSON Schema][LSP2#jsonurl]
+For construction of the JSONURL value see: [LSP2 ERC725Y JSON Schema > `valueContent = JSONURL`][LSP2#jsonurl]
 
 The linked JSON file SHOULD have the following format:
 
@@ -486,7 +487,7 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [ERC777]: <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-777.md>
 [LSP1]: <./LSP-1-UniversalReceiver.md>
 [LSP2#jsonurl]: <./LSP-2-ERC725YJSONSchema.md#JSONURL>
-[LSP2#bytes20mapping]: <./LSP-2-ERC725YJSONSchema.md#bytes20mapping>
+[LSP2#mapping]: <./LSP-2-ERC725YJSONSchema.md#mapping>
 [LSP4#erc725ykeys]: <./LSP-4-DigitalAsset-Metadata.md#erc725ykeys>
 [LSP7]: <./LSP-7-DigitalAsset.md>
 [LSP8]: <./LSP-8-IdentifiableDigitalAsset.md>


### PR DESCRIPTION
this follow the changes introduced in https://github.com/lukso-network/LIPs/commit/2d2c727956ad1fe0bcbb496e6719a626925b116b

## Feat

- [x] changed data keys `Bytes20Mapping` > `Mapping`
- [x] changed data keys `Bytes20MappingWithGrouping` > `MappingWithGrouping`

## Fix

- [x] fixed valueContent for LSP4CreatorsMap (index and interfaceId order)
- [x] fixed error in example for `MappingWithGrouping` in LSP2