### PR TITLE
change `SupportedStandards` Keys

### DIFF
--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -517,7 +517,7 @@ Using such schema allows interfaces to auto decode and interpret the values retr
 [
     {
         "name": "SupportedStandards:LSP3UniversalProfile",
-        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
+        "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
         "keyType": "Mapping",
         "valueType": "bytes4",
         "valueContent": "0xabe425d6"

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -36,7 +36,7 @@ The supported standard SHOULD be `LSP3UniversalProfile`
 ```json
 {
     "name": "SupportedStandards:LSP3UniversalProfile",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
+    "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
     "keyType": "Mapping",
     "valueType": "bytes4",
     "valueContent": "0xabe425d6"
@@ -188,7 +188,7 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
 [
     {
         "name": "SupportedStandards:LSP3UniversalProfile",
-        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
+        "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
         "keyType": "Mapping",
         "valueType": "bytes4",
         "valueContent": "0xabe425d6"

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -37,7 +37,7 @@ The supported standard SHOULD be `LSP4DigitalAsset`
 ```json
 {
     "name": "SupportedStandards:LSP4DigitalAsset",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
+    "key": "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
     "keyType": "Mapping",
     "valueType": "bytes4",
     "valueContent": "0xa4d96624"
@@ -233,7 +233,7 @@ ERC725Y JSON Schema `LSP4DigitalAsset`:
 [
     {
         "name": "SupportedStandards:LSP4DigitalAsset",
-        "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
+        "key": "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
         "keyType": "Mapping",
         "valueType": "bytes4",
         "valueContent": "0xa4d96624"

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -157,10 +157,10 @@ The 0 bytes part will represent a part that is dynamic. Below is an example base
 
 ```js
 name: "SupportedStandards:LSP3UniversalProfile"
-key: 0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6
+key: 0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38
 ```
 
-By setting the value to `0xeafec4d89fa9619884b6b8913562645500000000000000000000000000000000` in the list of allowed ERC725Y data keys, one address can set any data key **starting with the first word `SupportedStandards:...`**.
+By setting the value to `0xeafec4d89fa9619884b600000000000000000000000000000000000000000000` in the list of allowed ERC725Y data keys, one address can set any data key **starting with the first word `SupportedStandards:...`**.
 
 ### Permission Values in AddressPermissions:Permissions:\<address\>
 


### PR DESCRIPTION
## What does this PR introduce?
- Fixing the `SupportedStandards:XYZ` Keys after the change in LSP2.

- TODO: Add `SupportedStandards:LSP9Vault` in LSP9