### PR TITLE
Improve LSP1-UniversalReceiver standard

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -213,10 +213,10 @@ interface ILSP0  /* is ERC165 */ {
 
     // LSP1
 
-    event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
+    event UniversalReceiver(address indexed from, uint256 value, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
     
 
-    function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory);
+    function universalReceiver(bytes32 typeId, bytes memory data) external payable returns (bytes memory);
 
 }
 

--- a/LSPs/LSP-1-UniversalReceiver.md
+++ b/LSPs/LSP-1-UniversalReceiver.md
@@ -213,11 +213,11 @@ contract MyWallet is ERC165, ILSP1 {
         if(ERC165Checker.supportsInterface(universalReceiverDelegate,_INTERFACE_ID_LSP1_DELEGATE)){
 
             // Call the universalReceiverDelegate function on universalReceiverDelegate address
-            returneddata = ILSP1Delegate(universalReceiverDelegate).universalReceiverDelegate(msg.sender, msg.value, typeId, data);
+            returnedData = ILSP1Delegate(universalReceiverDelegate).universalReceiverDelegate(msg.sender, msg.value, typeId, data);
         }
 
-        emit UniversalReceiver(msg.sender, msg.value, typeId, returneddata, data);
-        return returneddata;
+        emit UniversalReceiver(msg.sender, msg.value, typeId, returnedData, data);
+        return returnedData;
     }
 }
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -186,10 +186,10 @@ interface ILSP9  /* is ERC165 */ {
 
     // LSP1
 
-    event UniversalReceiver(address indexed from, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
+    event UniversalReceiver(address indexed from, uint256 value, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
     
 
-    function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory);
+    function universalReceiver(bytes32 typeId, bytes memory data) external payable returns (bytes memory);
 
 
     // LSP9 


### PR DESCRIPTION
## What does this PR introduce?
- Mark `universalReceiver` function as payable
- Add value param to the UniversalReceiver event
- Add value param to the `universalReceiverDelegate` function
- Change the `LSP1Delegate` InterfaceID