### PR TITLE
Use tuple of instead of `Mixed` for LSP2 Map data keys

### DIFF
--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -61,8 +61,8 @@ Value example: `0x8c1d44f6000000000000000c` (interfaceId: `0x8c1d44f6`, index po
     "name": "LSP10VaultsMap:<address>",
     "key": "0x192448c3c0f88c7f238c0000<address>",
     "keyType": "Mapping",
-    "valueContent": "Mixed",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "Mixed"
 }
 ```
 
@@ -80,15 +80,15 @@ ERC725Y JSON Schema `LSP10ReceivedVaults`:
         "name": "LSP10Vaults[]",
         "key": "0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06",
         "keyType": "Array",
-        "valueContent": "Address",
-        "valueType": "address"
+        "valueType": "address",
+        "valueContent": "Address"
     },
     {
         "name": "LSP10VaultsMap:<address>",
         "key": "0x192448c3c0f88c7f238c0000<address>",
         "keyType": "Mapping",
-        "valueContent": "Mixed",
-        "valueType": "bytes"
+        "valueType": "(bytes4,bytes8)",
+        "valueContent": "(Bytes4,Number)"
     }
 ]
 ```

--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -38,8 +38,8 @@ References issued smart contract vaults.
     "name": "LSP10Vaults[]",
     "key": "0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06",
     "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
 }
 ```
 
@@ -61,8 +61,8 @@ Value example: `0x8c1d44f6000000000000000c` (interfaceId: `0x8c1d44f6`, index po
     "name": "LSP10VaultsMap:<address>",
     "key": "0x192448c3c0f88c7f238c0000<address>",
     "keyType": "Mapping",
-    "valueType": "bytes",
-    "valueContent": "Mixed"
+    "valueType": "(bytes4,bytes8)",
+    "valueContent": "(Bytes4,Number)"
 }
 ```
 

--- a/LSPs/LSP-12-IssuedAssets.md
+++ b/LSPs/LSP-12-IssuedAssets.md
@@ -70,8 +70,8 @@ Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index po
     "name": "LSP12IssuedAssetsMap:<address>",
     "key": "0x74ac2555c10b9349e78f0000<address>",
     "keyType": "Mapping",
-    "valueType": "bytes",
-    "valueContent": "Mixed"
+    "valueType": "(bytes4,bytes8)",
+    "valueContent": "(Bytes4,Number)"
 }
 ```
 
@@ -93,8 +93,8 @@ ERC725Y JSON Schema `LSP12IssuedAssets`:
         "name": "LSP12IssuedAssetsMap:<address>",
         "key": "0x74ac2555c10b9349e78f0000<address>",
         "keyType": "Mapping",
-        "valueType": "bytes",
-        "valueContent": "Mixed"
+        "valueType": "(bytes4,bytes8)",
+        "valueContent": "(Bytes4,Number)"
     }
 ]
 ```

--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -95,7 +95,7 @@ The `keyType` determines the format of the data key(s).
 
 ### `valueType`
 
-Describes the underlying data type of a value stored under a specific ERC725Y data key. It refers to the type for the smart contract language like [Solidity](https://docs.soliditylang.org).
+Describes the underlying data type(s) of a value stored under a specific ERC725Y data key. It refers to the type for the smart contract language like [Solidity](https://docs.soliditylang.org).
 
 The `valueType` is relevant for interfaces to know how a value MUST be encoded/decoded. This include:
 
@@ -117,6 +117,8 @@ The `valueType` can also be useful for typecasting. It enables contracts or inte
 | `address[]`   | an array of addresses |
 | `bytes[]`     | an array of dynamic size bytes  |
 | `bytesN[]`    | an array of fixed size bytes  |
+
+The `valueType` can also be a **tuple of types**, meaning the value stored under the ERC725Y data key is a mixture of multiple value types concatenated together. In such case, the types MUST be defined between parentheses. For instance: `(bytes4,bytes8)` or `(bytes8,address)`
 
 ### `valueContent`
 
@@ -142,8 +144,10 @@ Valid `valueContent` are:
 | [`JSONURL`](#jsonurl)     |  hash function, hash and link to the JSON file |
 | `Markdown`        | a structured Markdown mostly encoded as UTF8 string  |
 | `0x1345ABCD...`   | a **literal** value, when the returned value is expected to equal some specific bytes |
-| `Mixed`           | bytes that are a mixture of multiple types or encoding concatenated together |
 
+The `valueContent` field can also define a tuple of value contents (for instance, when the `valueType` is a tuple of types, as described above). In this case, each value content MUST be defined between parentheses. For instance: `(Bytes4,Number)`.
+
+This is useful for decoding tools, to know how to interpret each value type in the tuple.
 
 ---
 

--- a/LSPs/LSP-3-UniversalProfile-Metadata.md
+++ b/LSPs/LSP-3-UniversalProfile-Metadata.md
@@ -212,8 +212,8 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
         "name": "LSP12IssuedAssetsMap:<address>",
         "key": "0x74ac2555c10b9349e78f0000<address>",
         "keyType": "Mapping",
-        "valueType": "bytes",
-        "valueContent": "Mixed"
+        "valueType": "(bytes4,bytes8)",
+        "valueContent": "(Bytes4,Number)"
     },
 
     // from LSP5 ReceivedAssets
@@ -228,8 +228,8 @@ ERC725Y JSON Schema `LSP3UniversalProfile`:
         "name": "LSP5ReceivedAssetsMap:<address>",
         "key": "0x812c4334633eb816c80d0000<address>",
         "keyType": "Mapping",
-        "valueType": "bytes",
-        "valueContent": "Mixed"
+        "valueType": "(bytes4,bytes8)",
+        "valueContent": "(Bytes4,Number)"
     },
 
     // from ERC725Account

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -213,8 +213,8 @@ Where:
     "name": "LSP4CreatorsMap:<address>",
     "key": "0x6de85eaf5d982b4e5da00000<address>",
     "keyType": "Mapping",
-    "valueType": "bytes",
-    "valueContent": "Mixed"
+    "valueType": "(bytes4,bytes8)",
+    "valueContent": "(Bytes4,Number)"
 }
 ```
 
@@ -270,8 +270,8 @@ ERC725Y JSON Schema `LSP4DigitalAsset`:
         "name": "LSP4CreatorsMap:<address>",
         "key": "0x6de85eaf5d982b4e5da00000<address>",
         "keyType": "Mapping",
-        "valueType": "bytes",
-        "valueContent": "Mixed"
+        "valueType": "(bytes4,bytes8)",
+        "valueContent": "(Bytes4,Number)"
     }
 ]
 ```

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -64,8 +64,8 @@ Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index po
     "name": "LSP5ReceivedAssetsMap:<address>",
     "key": "0x812c4334633eb816c80d0000<address>",
     "keyType": "Mapping",
-    "valueType": "bytes",
-    "valueContent": "Mixed"
+    "valueType": "(bytes4,bytes8)",
+    "valueContent": "(Bytes4,Number)"
 }
 ```
 
@@ -89,8 +89,8 @@ ERC725Y JSON Schema `LSP5ReceivedAssets`:
         "name": "LSP5ReceivedAssetsMap:<address>",
         "key": "0x812c4334633eb816c80d0000<address>",
         "keyType": "Mapping",
-        "valueType": "bytes",
-        "valueContent": "Mixed"
+        "valueType": "(bytes4,bytes8)",
+        "valueContent": "(Bytes4,Number)"
     },
 ]
 ```


### PR DESCRIPTION
# What does this PR introduce?

## Current issue

Currently most Map data keys schemas define the valueContent as `Mixed`.

This does not provide context on how to decode and interpret the raw underlying bytes stored under such keys, as these could be of any types.

## Suggested changes

1. add description about the possibility of using tuple of types for:

- `valueType` = _e.g._ `(bytes4,bytes8)`
- `valueContent` = _e.g._ `(Bytes4,Number)`

2. change Map keys in LSP4, LSP5, LSP10 and LSP12 to use tuples for `valueType` and `valueContent`