### PR TITLE
Add missing Boolean type on LSP-2

### DIFF
--- a/LSPs/LSP-2-ERC725YJSONSchema.md
+++ b/LSPs/LSP-2-ERC725YJSONSchema.md
@@ -132,6 +132,7 @@ Valid `valueContent` are:
 
 | `valueContent`    | Description  |
 |---|---|
+| `Boolean`         | a boolean |
 | `String`          | an UTF8 encoded string |
 | `Address`         | an address |
 | `Number`          | a Number (positive or negative, depending on the `keyType`)  |


### PR DESCRIPTION
Line [62](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md?plain=1#L62) says there is `Boolean` but `Boolean` was missing from the main content table.
Either we delete from L62 or we add it as per this PR.