### PR TITLE
chore: updated permissions declaration/description format

### DIFF
--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -174,7 +174,7 @@ CHANGEOWNER         = 0x00000000000000000000000000000000000000000000000000000000
 // Allows changing the permissions (adding + removing) of addresses
 CHANGEPERMISSIONS   = 0x0000000000000000000000000000000000000000000000000000000000000002;
 // .... .... .... 0100 
-// Allows adding new permissions to addresses (removing permission disallowed) 
+// Allows adding new controller addresses by granting them some permissions
 ADDPERMISSIONS      = 0x0000000000000000000000000000000000000000000000000000000000000004;
 // .... .... .... 1000 
 // Allows setting data on the controlled contract

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -183,7 +183,7 @@ SETDATA             = 0x00000000000000000000000000000000000000000000000000000000
 // Allows calling other contracts through the controlled contract
 CALL                = 0x0000000000000000000000000000000000000000000000000000000000000010;
 // .... .... 0010 .... 
-// Allows calling other contracts through the controlled contract
+// Allows static calling other contracts through the controlled contract, while restrcting any state modifications during the call (or any subcalls, if present)
 STATICCALL          = 0x0000000000000000000000000000000000000000000000000000000000000020;
 // .... .... 0100 .... 
 // Allows delegate calling other contracts through the controlled contract

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -74,7 +74,7 @@ For more informations about how to access each index of the `AddressPermissions[
 
 Contains a set of permissions for an address. Permissions defines what an address **can do on** an ERC725Account (*eg: edit the data key-value store via SETDATA*), or **can perform on behalf of** the ERC725Account.
 
-Since the `valueType` of this data key is `bytes32`, up to 255 different permissions can be defined. This includes the [ten default permissions](#permission-values-in-addresspermissionspermissionsaddress) defined below. Custom permissions can be defined on top of the default one (starting at `0x0000...0400` (`1024` in decimals)).
+Since the `valueType` of this data key is `bytes32`, up to 255 different permissions can be defined. This includes the [ten default permissions](#permission-values-in-addresspermissionspermissionsaddress) defined below. Custom permissions can be defined on top of the default one (starting at `0x0000...8000` (`32768` in decimals)).
 
 ```json
 {

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -189,7 +189,7 @@ STATICCALL          = 0x00000000000000000000000000000000000000000000000000000000
 // Allows delegate calling other contracts through the controlled contract
 DELEGATECALL        = 0x0000000000000000000000000000000000000000000000000000000000000040;
 // .... .... 1000 .... 
-// Allows deploying other contracts through the controlled contract
+// Allows deploying new contracts through the controlled contract
 DEPLOY              = 0x0000000000000000000000000000000000000000000000000000000000000080;
 // .... 0001 .... .... 
 // Allows transfering value to other contracts from the controlled contract

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -167,21 +167,51 @@ By setting the value to `0xeafec4d89fa9619884b6000000000000000000000000000000000
 The following permissions are allowed in the BitArray of the `AddressPermissions:Permissions:<address>` data key for an address. The order can not be changed:
 
 ```js
-CHANGEOWNER         = 0x0000000000000000000000000000000000000000000000000000000000000001;   // 0000 0000 0000 0001 // Allows changing the owner of the controlled contract
-CHANGEPERMISSIONS   = 0x0000000000000000000000000000000000000000000000000000000000000002;   // .... .... .... 0010 // Allows changing the permissions (adding + removing) of addresses
-ADDPERMISSIONS      = 0x0000000000000000000000000000000000000000000000000000000000000004;   // .... .... .... 0100 // Allows adding new permissions to addresses (removing permission disallowed) 
-SETDATA             = 0x0000000000000000000000000000000000000000000000000000000000000008;   // .... .... .... 1000 // Allows setting data on the controlled contract
-CALL                = 0x0000000000000000000000000000000000000000000000000000000000000010;   // .... .... 0001 .... // Allows calling other contracts through the controlled contract
-STATICCALL          = 0x0000000000000000000000000000000000000000000000000000000000000020;   // .... .... 0010 .... // Allows calling other contracts through the controlled contract
-DELEGATECALL        = 0x0000000000000000000000000000000000000000000000000000000000000040;   // .... .... 0100 .... // Allows delegate calling other contracts through the controlled contract
-DEPLOY              = 0x0000000000000000000000000000000000000000000000000000000000000080;   // .... .... 1000 .... // Allows deploying other contracts through the controlled contract
-TRANSFERVALUE       = 0x0000000000000000000000000000000000000000000000000000000000000100;   // .... 0001 .... .... // Allows transfering value to other contracts from the controlled contract
-SIGN                = 0x0000000000000000000000000000000000000000000000000000000000000200;   // .... 0010 .... .... // Allows signing on behalf of the controlled account, for example for login purposes
-SUPER_SETDATA       = 0x0000000000000000000000000000000000000000000000000000000000000400; // .... 0100 .... .... // same as SETDATA, but without restricting to specific data keys
-SUPER_TRANSFERVALUE = 0x0000000000000000000000000000000000000000000000000000000000000800; // .... 1000 .... .... // same as TRANSFERVALUE, but without restricting to specific addresses, functions or standards
-SUPER_CALL          = 0x0000000000000000000000000000000000000000000000000000000000001000; // 0001 .... .... .... // same as CALL, but without restricting to specific addresses, functions or standards
-SUPER_STATICCALL    = 0x0000000000000000000000000000000000000000000000000000000000002000; // 0010 .... .... .... // same as STATICCALL, but without restricting to specific addresses, functions or standards
-SUPER_DELEGATECALL  = 0x0000000000000000000000000000000000000000000000000000000000004000; // 0100 .... .... .... // same as DELEGATECALL, but without restricting to specific addresses, functions or standards
+// 0000 0000 0000 0001 
+// Allows changing the owner of the controlled contract
+CHANGEOWNER         = 0x0000000000000000000000000000000000000000000000000000000000000001;
+// .... .... .... 0010 
+// Allows changing the permissions (adding + removing) of addresses
+CHANGEPERMISSIONS   = 0x0000000000000000000000000000000000000000000000000000000000000002;
+// .... .... .... 0100 
+// Allows adding new permissions to addresses (removing permission disallowed) 
+ADDPERMISSIONS      = 0x0000000000000000000000000000000000000000000000000000000000000004;
+// .... .... .... 1000 
+// Allows setting data on the controlled contract
+SETDATA             = 0x0000000000000000000000000000000000000000000000000000000000000008;
+// .... .... 0001 .... 
+// Allows calling other contracts through the controlled contract
+CALL                = 0x0000000000000000000000000000000000000000000000000000000000000010;
+// .... .... 0010 .... 
+// Allows calling other contracts through the controlled contract
+STATICCALL          = 0x0000000000000000000000000000000000000000000000000000000000000020;
+// .... .... 0100 .... 
+// Allows delegate calling other contracts through the controlled contract
+DELEGATECALL        = 0x0000000000000000000000000000000000000000000000000000000000000040;
+// .... .... 1000 .... 
+// Allows deploying other contracts through the controlled contract
+DEPLOY              = 0x0000000000000000000000000000000000000000000000000000000000000080;
+// .... 0001 .... .... 
+// Allows transfering value to other contracts from the controlled contract
+TRANSFERVALUE       = 0x0000000000000000000000000000000000000000000000000000000000000100;
+// .... 0010 .... .... 
+// Allows signing on behalf of the controlled account, for example for login purposes
+SIGN                = 0x0000000000000000000000000000000000000000000000000000000000000200;
+// .... 0100 .... .... 
+// Same as SETDATA, but without restricting to specific data keys
+SUPER_SETDATA       = 0x0000000000000000000000000000000000000000000000000000000000000400;
+// .... 1000 .... .... 
+// Same as TRANSFERVALUE, but without restricting to specific addresses, functions or standards
+SUPER_TRANSFERVALUE = 0x0000000000000000000000000000000000000000000000000000000000000800;
+// 0001 .... .... .... 
+// Same as CALL, but without restricting to specific addresses, functions or standards
+SUPER_CALL          = 0x0000000000000000000000000000000000000000000000000000000000001000;
+// 0010 .... .... .... 
+// Same as STATICCALL, but without restricting to specific addresses, functions or standards
+SUPER_STATICCALL    = 0x0000000000000000000000000000000000000000000000000000000000002000;
+// 0100 .... .... .... 
+// Same as DELEGATECALL, but without restricting to specific addresses, functions or standards
+SUPER_DELEGATECALL  = 0x0000000000000000000000000000000000000000000000000000000000004000;
 ```
 
 ![LSP6 - KeyManager-permissions-examples](../assets/LSP-6/lsp6-default-permissions-range.jpeg)


### PR DESCRIPTION
# What this PR introduces? 

Updated block of JS code where permissions' names and values are declared, with related documentation.
Moved JS docs for permissions to be on top of each permission constant, not on the same line as the constant as these docs were almost invisible.

![Screenshot 2022-08-02 at 11 56 52](https://user-images.githubusercontent.com/36865532/182338835-f8c89fb8-136d-447e-acbb-dc1a55df2e03.png)


Other related topics to discuss are:
1) the naming of `SUPER_...` permissions;
    Suggest removing `SUPER_` prefix from permissions that have no limitations and adding prefix to permissions that **represent a subset** of current `SUPER_` permissions. 
2) Image with an example of permissions - looks like Alice doesn't have SUPER permissions and the total value of assigned permissions `0x...ffff` shown on the right side of the image is incorrect? In [`lsp-smart-contracts`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/constants.js#L170) the default `ALL_PERMISSIONS` value is `0x7FBF` which includes all permissions except `DELEGATECALL`, I suppose for security reasons. Bits for permissions that are not declared in this standard are set to 0 in constants in lsp-smart-contracts repository (link is above) but on the image, it feels like all 32 bytes are set to `0xF`. As I recall all bytes were `0xF` initially but later updated to zero out all permissions that do not exist in the standard yet.
