### PR TITLE
Change NFT to non-divisible

### DIFF
--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -45,7 +45,7 @@ function decimals() external view returns (uint256);
 
 Returns the number of decimals used to get its user representation.
 
-If the token is an NFT then `0` SHOULD be used, otherwise `18` is the common value.
+If the token is non-divisible then `0` SHOULD be used, otherwise `18` is the common value.
 
 **Returns:** `uint256` the number of decimals to tranfrom a token value when displaying.
 


### PR DESCRIPTION
Assuming that LSP7 is for tokens like ERC20, not NFT like LSP8 it might be confusing in sense that some might think that setting isNFT to true would create an NFT, which is not entirely true. In this sense the param should be rather called isNonDivisible.