### PR TITLE
Mistake in LSP-7-DigitalAsset doc

### DIFF
--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -114,7 +114,7 @@ _Requirements:_
 #### isOperatorFor
 
 ```solidity
-function isOperatorFor(address tokenOwner, address operator) external view returns (uint256);
+function isOperatorFor(address operator, address tokenOwner) external view returns (uint256);
 ```
 
 Returns amount of tokens `operator` address has access to from `tokenOwner`.


### PR DESCRIPTION
Mistake in the LSP7DigitalAsset docs. Input parameters for `isOperatorFor` is flipped around  (operator <-> tokenOwner )