### PR TITLE
Fix mappings data keys errors

### DIFF
--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -54,7 +54,7 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 - `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of a [LSP9Vaults](./LSP-9-Vault.md): `0x8c1d44f6`.
 - `indexNumber` = the index in the [`LSP10Vaults[]` Array](#lsp10vaults)
 
-Value example: `0x8c1d44f6000000000000000c` (interfaceId: `0x8c1d44f6`, index position `0x000000000000000c = 16`).
+Value example: `0x8c1d44f6000000000000000c` (interfaceId: `0x8c1d44f6`, index position `0x000000000000000c = 12`).
 
 ```json
 {

--- a/LSPs/LSP-10-ReceivedVaults.md
+++ b/LSPs/LSP-10-ReceivedVaults.md
@@ -14,10 +14,10 @@ This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob
 
 ## Abstract
 The following two data keys (including their ERC725Y JSON schema) are proposed to represent vaults owned by a smart contract:
-- `LSP10ReceivedVaults[]` to hold an array of vault addresses
-- `LSP10ReceivedVaultsMap` to hold a mapping of the index in the former array and the interface ID of the standard used by the vault. This enables to quickly differentiate vaults standards apart without the need to query each vault smart contract separately. 
+- `LSP10Vaults[]` to hold an array of vault addresses
+- `LSP10VaultsMap` to hold a mapping of the index in the former array and the interface ID of the standard used by the vault. This enables to quickly differentiate vaults standards apart without the need to query each vault smart contract separately. 
 
-The data key `LSP10ReceivedVaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
+The data key `LSP10VaultsMap` also helps to prevent adding duplications to the array, when automatically added via smart contract (e.g. a [LSP1-UniversalReceiverDelegate](./LSP-1-UniversalReceiver.md)).
 
 ## Motivation
 To be able to display received vaults in a profile we need to keep track of all received vaults contract addresses. This is important for [LSP3 UniversalProfile](./LSP-3-UniversalProfile.md), but also Assets smart contracts via [LSP5-ReceivedAssets](./LSP-5-ReceivedAssets.md) Standard.

--- a/LSPs/LSP-12-IssuedAssets.md
+++ b/LSPs/LSP-12-IssuedAssets.md
@@ -63,7 +63,7 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 - `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0xffffffff`).
 - `indexNumber` = the index in the [`LSP12IssuedAssets[]` Array](#LSP12Issuedassets)
 
-Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index position `0x000000000000000c = 16`).
+Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index position `0x000000000000000c = 12`).
 
 ```json
 {

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -57,7 +57,7 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 - `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0xffffffff`).
 - `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp5receivedassets)
 
-Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index position `0x000000000000000c = 16`).
+Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index position `0x000000000000000c = 12`).
 
 ```json
 {


### PR DESCRIPTION
# What does this PR introduce?

- [x] fix incorrect number conversion in Issued/Received Assets Maps + Received Vaults (`0x00...0c` = `12` ✅ , not ~`16`~ ❌ )
- [x] edit incorrect references to ERC725Y data keys in LSP10