### PR TITLE
[QSP - Best Practices] Change isOperatorFor(..) to authorizedAmountFor(..) in LSP7

### DIFF
--- a/LSPs/LSP-12-IssuedAssets.md
+++ b/LSPs/LSP-12-IssuedAssets.md
@@ -63,7 +63,7 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 - `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0xffffffff`).
 - `indexNumber` = the index in the [`LSP12IssuedAssets[]` Array](#LSP12Issuedassets)
 
-Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index position `0x000000000000000c = 12`).
+Value example: `0x5fcaac27000000000000000c` (interfaceId: `0x5fcaac27`, index position `0x000000000000000c = 12`).
 
 ```json
 {

--- a/LSPs/LSP-12-IssuedAssets.md
+++ b/LSPs/LSP-12-IssuedAssets.md
@@ -63,7 +63,7 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 - `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0xffffffff`).
 - `indexNumber` = the index in the [`LSP12IssuedAssets[]` Array](#LSP12Issuedassets)
 
-Value example: `0x5fcaac27000000000000000c` (interfaceId: `0x5fcaac27`, index position `0x000000000000000c = 12`).
+Value example: `0x5fcaac27000000000000000c` (interfaceId: `0x5fcaac27` for a [LSP7](./LSP-7-DigitalAsset.md) token, index position `0x000000000000000c = 12`).
 
 ```json
 {

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -57,7 +57,7 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 - `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0xffffffff`).
 - `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp5receivedassets)
 
-Value example: `0x5fcaac27000000000000000c` (interfaceId: `0x5fcaac27`, index position `0x000000000000000c = 12`).
+Value example: `0x5fcaac27000000000000000c` (interfaceId: `0x5fcaac27` for a [LSP7](./LSP-7-DigitalAsset.md) token, index position `0x000000000000000c = 12`).
 
 ```json
 {

--- a/LSPs/LSP-5-ReceivedAssets.md
+++ b/LSPs/LSP-5-ReceivedAssets.md
@@ -57,7 +57,7 @@ The data value MUST be constructed as follows: `bytes4(standardInterfaceId) + by
 - `standardInterfaceId` = the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the token or asset smart contract implements (if the ERC165 interface ID is unknown, `standardInterfaceId = 0xffffffff`).
 - `indexNumber` = the index in the [`LSP5ReceivedAssets[]` Array](#lsp5receivedassets)
 
-Value example: `0xe33f65c3000000000000000c` (interfaceId: `0xe33f65c3`, index position `0x000000000000000c = 12`).
+Value example: `0x5fcaac27000000000000000c` (interfaceId: `0x5fcaac27`, index position `0x000000000000000c = 12`).
 
 ```json
 {

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -114,10 +114,10 @@ _Requirements:_
 - `operator` cannot be calling address.
 - `operator` cannot be the zero address.
 
-#### isOperatorFor
+#### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address tokenOwner, address operator) external view returns (uint256);
+function authorizedAmountFor(address tokenOwner, address operator) external view returns (uint256);
 ```
 
 Returns amount of tokens `operator` address has access to from `tokenOwner`.
@@ -300,7 +300,7 @@ interface ILSP7 is /* IERC165 */ {
 
     function revokeOperator(address to, uint256 amount) external;
 
-    function isOperatorFor(address operator, address tokenOwner) external view returns (uint256);
+    function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256);
 
     function transfer(address from, address to, uint256 amount, bool force, bytes memory data) external;
 

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -117,10 +117,10 @@ _Requirements:_
 #### authorizedAmountFor
 
 ```solidity
-function authorizedAmountFor(address tokenOwner, address operator) external view returns (uint256);
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256);
 ```
 
-Returns amount of tokens `operator` address has access to from `tokenOwner`.
+Returns amount of tokens `operator` address is authorized to spent from `tokenOwner`.
 Operators can send and burn tokens on behalf of their owners. The tokenOwner is their own operator.
 
 _Parameters:_

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -28,7 +28,7 @@ A commonality with [LSP8 IdentifiableDigitalAsset][LSP8] is desired so that the 
 
 ## Specification
 
-[ERC165] interface id: `0xe33f65c3`
+[ERC165] interface id: `0x5fcaac27`
 
 ### ERC725Y Data Keys
 


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ Breaking Change

- Change `isOperatorFor` in LSP7 to `authorizedAmountFor`
- Update the `interfaceId` of LSP7 `0xe33f65c3` -> `0x5fcaac27`

## Why is this PR needed?

`isOperatorFor(address operator, address tokenOwner)` this method returns `uint256`, the amount of tokens that `operator` is authorised to spend on behalf of `tokenOwner`. The naming of the method is quite misleading as one would expect that `isOperatorFor` would return a `bool`. That’s why the name `authorizedAmountFor` would fit better in this context.