### PR TITLE
Update InterfaceId of LSP0 and LSP9

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -39,7 +39,7 @@ This allows us to:
 
 ## Specification
 
-[ERC165] interface id: `0x9a3bfe88`
+[ERC165] interface id: `0xeb6be62e`
 
 _This interface id can be used to detect ERC725Account contracts._
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -24,7 +24,7 @@ This standard defines a vault that can hold assets and interact with other contr
 
 ## Specification
 
-[ERC165] interface id: `0x8c1d44f6`
+[ERC165] interface id: `0xfd4d5c50`
 
 _This interface id can be used to detect Vault contracts._
 


### PR DESCRIPTION
## What does this PR introduce?
- Update InterfaceId of LSP0 and LSP9.

Updating ClaimOwnership InterfaceId affected LSP0 and LSP9 InterfaceIds as renounceOwnership function is part of the InterfaceId.


