### PR TITLE
Switch the returnedValue with the receivedData values in UniversalReceiver Event

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -254,7 +254,7 @@ interface ILSP0  /* is ERC165 */ {
 
     // LSP1
 
-    event UniversalReceiver(address indexed from, uint256 value, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
+    event UniversalReceiver(address indexed from, uint256 indexed value, bytes32 indexed typeId, bytes receivedData, bytes returnedValue);
     
 
     function universalReceiver(bytes32 typeId, bytes memory data) external payable returns (bytes memory);

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -228,7 +228,7 @@ interface ILSP0  /* is ERC165 */ {
     
     // ERC725Y
 
-    event DataChanged(bytes32 indexed dataKey);
+    event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
 
     function getData(bytes32 dataKey) external view returns (bytes memory dataValue);

--- a/LSPs/LSP-1-UniversalReceiver.md
+++ b/LSPs/LSP-1-UniversalReceiver.md
@@ -58,7 +58,7 @@ _Returns:_ `bytes`, which can be used to encode response values.
 #### UniversalReceiver
 
 ```solidity
-event UniversalReceiver(address indexed from, uint256 value, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData)
+event UniversalReceiver(address indexed from, uint256 indexed value, bytes32 indexed typeId, bytes receivedData, bytes returnedValue);
 ```
 
 This event MUST be emitted when the `universalReceiver` function is succesfully executed.
@@ -71,9 +71,9 @@ _Values:_
 
 - `typeId` is the hash of a standard, or the type relative to the `data` received.
 
-- `returnedValue` is the data returned from the `universalReceiver(..)` function.
-
 - `receivedData` is a byteArray of arbitrary data received.
+
+- `returnedValue` is the data returned from the `universalReceiver(..)` function.
 
 
 ## UniversalReceiverDelegate
@@ -168,7 +168,7 @@ contract MyWallet is ERC165, ILSP1 {
     }
 
     function universalReceiver(bytes32 typeId, bytes memory data) public payable returns (bytes memory) {
-        emit UniversalReceiver(msg.sender, msg.value, typeId, 0x0, data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, data, 0x);
         return 0x0;
     }
 }
@@ -229,7 +229,7 @@ contract MyWallet is ERC165, ILSP1 {
             returnedData = ILSP1Delegate(universalReceiverDelegate).universalReceiverDelegate(msg.sender, msg.value, typeId, data);
         }
 
-        emit UniversalReceiver(msg.sender, msg.value, typeId, returnedData, data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, data, returnedData);
         return returnedData;
     }
 }
@@ -259,7 +259,7 @@ contract UniversalReceiverDelegate is ERC165, ILSP1Delegate {
 
 interface ILSP1  /* is ERC165 */ {
 
-    event UniversalReceiver(address indexed from, uint256 value, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
+    event UniversalReceiver(address indexed from, uint256 value, bytes32 indexed typeId, bytes receivedData, bytes returnedValue);
     
     
     function universalReceiver(bytes32 typeId, bytes memory data) external payable returns (bytes memory);

--- a/LSPs/LSP-1-UniversalReceiver.md
+++ b/LSPs/LSP-1-UniversalReceiver.md
@@ -73,7 +73,7 @@ _Values:_
 
 - `receivedData` is a byteArray of arbitrary data received.
 
-- `returnedValue` is the data returned from the `universalReceiver(..)` function.
+- `returnedValue` is the data returned by the `universalReceiver(..)` function.
 
 
 ## UniversalReceiverDelegate

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -269,7 +269,7 @@ interface ILSP7 is /* IERC165 */ {
 
     // ERC725Y
 
-    event DataChanged(bytes32 indexed dataKey);
+    event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
 
     function getData(bytes32 dataKey) external view returns (bytes memory value);

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -482,7 +482,7 @@ interface ILSP8 is /* IERC165 */ {
 
     // ERC725Y
 
-    event DataChanged(bytes32 indexed dataKey);
+    event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
 
     function getData(bytes32 dataKey) external view returns (bytes memory value);

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -278,7 +278,7 @@ interface ILSP9  /* is ERC165 */ {
 
     // LSP1
 
-    event UniversalReceiver(address indexed from, uint256 value, bytes32 indexed typeId, bytes indexed returnedValue, bytes receivedData);
+    event UniversalReceiver(address indexed from, uint256 indexed value, bytes32 indexed typeId, bytes receivedData, bytes returnedValue);
     
 
     function universalReceiver(bytes32 typeId, bytes memory data) external payable returns (bytes memory);

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -264,7 +264,7 @@ interface ILSP9  /* is ERC165 */ {
     
     // ERC725Y
 
-    event DataChanged(bytes32 indexed dataKey);
+    event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
 
     function getData(bytes32 dataKey) external view returns (bytes memory dataValue);


### PR DESCRIPTION
## What does this PR introduce
- Marking the value field as indexed
- Remove the indexed from the returnedValue
- Switch between receivedData and returnedValue parameters.
- Add dataValue param to LSP0 - LSP7 - LSP8 - LSP9

Before: 
```js
event UniversalReceiver(
     address indexed from,
     uint256 value,
     bytes32 indexed typeId,
     bytes indexed returnedValue,
     bytes receivedData,
);
```
Now: 

```js
event UniversalReceiver(
     address indexed from,
     uint256 indexed value,
     bytes32 indexed typeId,
     bytes receivedData,
     bytes returnedValue
);
```

Note: Event signature will not change since both switched parameters are bytes.