### PR TITLE
Create LSP14Ownable2Step specs 

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -79,6 +79,14 @@ Contains the methods from:
 - [LSP1](./LSP-1-UniversalReceiver.md#specification)
 - [LSP14](./LSP-14-Ownable2Step.md#specification)
 
+#### transferOwnership
+
+Similar to [`transferOwnership(address)`](./LSP-14-Ownable2Step.md#transferownership) from LSP14.
+
+**Additional requirements:**
+
+- The `newOwner` MUST NOT be the contract itself `address(this)`.
+
 #### fallback
 
 ```solidity
@@ -178,6 +186,8 @@ interface ILSP0  /* is ERC165 */ {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     event RenounceOwnershipInitiated();
+
+    event OwnershipRenounced();
 
 
     function owner() external view returns (address);

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -6,7 +6,7 @@ discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2021-09-21
-requires: ERC165, ERC173, ERC1271, ERC725X, ERC725Y, LSP1, LSP2
+requires: ERC165, ERC1271, ERC725X, ERC725Y, LSP1, LSP2, LSP14
 ---
 
 
@@ -41,7 +41,7 @@ This allows us to:
 
 ## Specification
 
-[ERC165] interface id: `0xeb6be62e`
+[ERC165] interface id: `0xdca05671`
 
 _This interface id can be used to detect ERC725Account contracts._
 
@@ -77,71 +77,7 @@ Contains the methods from:
 - [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor)
 - [ERC1271](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1271.md#specification)
 - [LSP1](./LSP-1-UniversalReceiver.md#specification)
-- Claim Ownership, a modified version of [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable). *See below for details*
-
-#### owner
-
-```solidity
-function owner() external view returns (address);
-```
-
-Returns the `address` of the current contract owner.
-
-#### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address);
-```
-
-Return the `address` of the pending owner, of a ownership transfer, that was initiated with `transferOwnership(address)`. MUST be `address(0)` if no ownership transfer is in progress.
-
-MUST be set when transferring ownership of the contract via `transferOwnership(address)` to a new `address`.
-
-SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
-
-
-#### transferOwnership
-
-```solidity
-function transferOwnership(address newOwner) external;
-```
-
-Sets the `newOwner` as `pendingOwner`.
-
-MUST be called only by `owner()`.
-
-The `newOwner` MUST NOT be the contract itself `address(this)`
-
-#### claimOwnership
-
-```solidity
-function claimOwnership() external;
-```
-
-Allow an `address` to become the new owner of the contract. MUST only be called by the pending owner.
-
-MUST be called after `transferOwnership` by the current `pendingOwner` to finalize the ownership transfer.
-
-MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event once the new owner has claimed ownership of the contract.
-
-#### renounceOwnership
-
-```solidity
-function renounceOwnership() public;
-```
-
-Leaves the contract without an owner. Once ownership of the contract is renounced, it MUST NOT be possible to call the functions restricted to the owner only.
-
-Since renouncing ownership is a sensitive operation, it SHOULD be done as a two step process by calling  `renounceOwnership(..)` twice. First to initiate the process, second as a confirmation.
-
-*Requirements:*
-
-- MUST be called only by the `owner()` only.
-- The second call MUST happen AFTER the delay of 100 blocks and within the next 100 blocks from the first `renounceOwnership(..)` call.
-- If the 200 block has passed, the `renounceOwnership(..)` call phase SHOULD reset the process, and a new one will be initated.
-
-MUST emit a [`RenounceOwnershipInitiated`](#renounceownershipinitiated) event on the first `renounceOwnership(..)` call.
-MUST emit [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event after successfully renouncing the ownership.
+- [LSP14](./LSP-14-Ownable2Step.md#specification)
 
 #### fallback
 
@@ -162,14 +98,6 @@ event ValueReceived(address indexed sender, uint256 indexed value);
 ```
 
 MUST be emitted when a native token transfer was received.
-
-#### RenounceOwnershipInitiated
-
-```solidity
-event RenounceOwnershipInitiated();
-```
-
-MUST be emitted when renouncing ownership of the contract is initiated.
 
 ## Rationale
 
@@ -198,24 +126,7 @@ ERC725Y JSON Schema `ERC725Account`:
 ```solidity
 interface ILSP0  /* is ERC165 */ {
          
-    
-    // Modified ERC173 (ClaimOwnership)
-    
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
-
-    function owner() external view returns (address);
-    
-    function pendingOwner() external view returns (address);
-
-    function transferOwnership(address newOwner) external; // onlyOwner
-
-    function claimOwnership() external;
-    
-    function renounceOwnership() external; // onlyOwner
         
-
-    
     // ERC725X
 
     event Executed(uint256 indexed operation, address indexed to, uint256 indexed  value, bytes4 selector);
@@ -258,6 +169,26 @@ interface ILSP0  /* is ERC165 */ {
     
 
     function universalReceiver(bytes32 typeId, bytes memory data) external payable returns (bytes memory);
+
+    
+    // LSP14
+
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    event RenounceOwnershipInitiated();
+
+
+    function owner() external view returns (address);
+    
+    function pendingOwner() external view returns (address);
+
+    function transferOwnership(address newOwner) external; // onlyOwner
+
+    function acceptOwnership() external;
+    
+    function renounceOwnership() external; // onlyOwner
 
 }
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -85,7 +85,7 @@ Contains the methods from:
 function transferOwnership(address newOwner) external;
 ```
 
-Similar to [`transferOwnership(address)`](./LSP-14-Ownable2Step.md#transferownership) from LSP14.
+This function is part of the [LSP14]((./LSP-14-Ownable2Step.md#transferownership)) Specification, with additional requirements as follows:
 
 **Additional requirements:**
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -81,6 +81,10 @@ Contains the methods from:
 
 #### transferOwnership
 
+```solidity
+function transferOwnership(address newOwner) external;
+```
+
 Similar to [`transferOwnership(address)`](./LSP-14-Ownable2Step.md#transferownership) from LSP14.
 
 **Additional requirements:**

--- a/LSPs/LSP-1-UniversalReceiver.md
+++ b/LSPs/LSP-1-UniversalReceiver.md
@@ -40,7 +40,7 @@ Every contract that complies with the Universal Receiver standard MUST implement
 #### universalReceiver
 
 ```solidity
-universalReceiver(bytes32 typeId, bytes memory data) public payable returns (bytes memory)
+function universalReceiver(bytes32 typeId, bytes memory data) public payable returns (bytes memory)
 ```
 
 Allows to be called by any external contract to inform the contract about any incoming transfers, interactions or simple information.
@@ -103,7 +103,12 @@ The UniversalReceiverDelegate contract should support the InterfaceId, otherwise
 
 
 ```solidity
-universalReceiverDelegate(address caller, uint256 value, bytes32 typeId, bytes memory data) public returns (bytes memory);
+function universalReceiverDelegate(
+    address caller, 
+    uint256 value, 
+    bytes32 typeId, 
+    bytes memory data
+) public returns (bytes memory);
 ```
 
 Allows to be called by any external contract when an address wants to delegate its universalReceiver functionality to another smart contract.

--- a/LSPs/LSP-14-Ownable2Step.md
+++ b/LSPs/LSP-14-Ownable2Step.md
@@ -23,9 +23,9 @@ Because owning the contract allows access to sensitive methods, transferring to 
 
 ## Motivation
 <!--The motivation is critical for LIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
-The particular issue that this implementation of [EIP173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) solves is the irreversible nature of transferring or renouncing ownership of a contract.
+The particular issue that the LSP14 standard solves is the irreversible nature of transferring or renouncing ownership of a contract.
 
-Transferring ownership of the contract in a single transaction does not guarantee that the address behind the new owner (EOA or contract) is controlled. For instance, if the new owner lost its private key or if the new owner is a contract that is in a locked state.
+Transferring ownership of the contract in a single transaction does not guarantee that the address behind the new owner (EOA or contract) is able to control the Ownable contract. For instance, if the new owner lost its private key or if the new owner is a contract that does not have any generic execution function.
 
 Letting the new owner accept ownership of the contract guarantees that the contract is owned by an address (EOA or contract) that can be controlled, and that control over the contract implementing LSP14 will not be lost.
 
@@ -40,8 +40,7 @@ _This interface id can be used to detect Ownable2Step contracts._
 
 ### Methods
 
-Contains the methods from:
-- [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable). *See below for details*
+The methods are based on the methods from [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable), with additional changes. *See below for details*
 
 #### owner
 
@@ -84,7 +83,7 @@ MUST emit a [`OwnershipTransferredStarted`](#ownershiptransferstarted) event onc
 
 - If the new owner address supports LSP1 interface, SHOULD call the new owner's [`universalReceiver(...)`] function with the following parameters below:
 
-    - `typeId`: keccak256('LSP14OwnershipTransferStarted')
+    - `typeId`: `keccak256('LSP14OwnershipTransferStarted')` > `0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0`
     - `data`: TBD
 
 #### acceptOwnership
@@ -93,7 +92,7 @@ MUST emit a [`OwnershipTransferredStarted`](#ownershiptransferstarted) event onc
 function acceptOwnership() external;
 ```
 
-Allows the `pendingOwner()` to become the new owner of the contract.
+Allows the `pendingOwner()` to accept ownership of the contract.
 
 This function MUST be called as the second step (after `transferOwnership(address)`) by the current `pendingOwner()` to finalize the ownership transfer.
 
@@ -105,14 +104,14 @@ MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#spec
 
 **LSP1 Hooks:**
 
-- if the previous owner is a contract that supports LSP1 interface, SHOULD call the previous owner's [`universalReceiver(...)`] function with the parameters below:
+- If the previous owner is a contract that supports LSP1 interface, SHOULD call the previous owner's [`universalReceiver(...)`] function with the parameters below:
 
-    - `typeId`: keccak256('LSP14OwnershipTransferred_SenderNotification')
+    - `typeId`: `keccak256('LSP14OwnershipTransferred_SenderNotification')` > `0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c`
     - `data`: TBD
 
-- if the new owner is a contract that supports LSP1 interface, SHOULD call the new owner's [`universalReceiver(...)`] function with the parameters below:
+- If the new owner is a contract that supports LSP1 interface, SHOULD call the new owner's [`universalReceiver(...)`] function with the parameters below:
 
-    - `typeId`: keccak256('LSP14OwnershipTransferred_RecipientNotification')
+    - `typeId`: `keccak256('LSP14OwnershipTransferred_RecipientNotification')` > `0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c`
     - `data`: TBD
 
 

--- a/LSPs/LSP-14-Ownable2Step.md
+++ b/LSPs/LSP-14-Ownable2Step.md
@@ -6,33 +6,30 @@ discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2022-09-23
-requires: ERC173
+requires: ERC173, LSP1
 ---
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the LIP.-->
-This standard describes a modified version of [EIP173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) that uses a a 2-step process to transfer or renounce ownership of a contract, instead of instant execution.
+This standard describes an extended version of [EIP173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) that uses a 2-step process to transfer or renounce ownership of a contract, instead of instant execution.
 
-In addition, this standard defines hooks in the form of external calls to:
+In addition, this standard defines hooks that call the `universalReceiver(...)` function of the current owner and new owner, if these addresses are contracts that implement LSP1. This aims to:
 - notify when the new owner of the contract should accept ownership.
 - notify the previous and new owner when ownership of the contract has been fully transferred.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-The particular issue that this implementation of [EIP173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) solves is the irreversible nature of transferring or renouncing ownership of a contract.
-
-Firstly, because owning the contract allows access to sensitive methods, transferring to the wrong address or renouncing ownership of the contract by accident in a single transaction can be highly dangerous. Having those two processes work in 2 steps substantially reduces the probability of transferring or renouncing ownership of the contract by accident.
+Because owning the contract allows access to sensitive methods, transferring to the wrong address or renouncing ownership of the contract by accident in a single transaction can be highly dangerous. Having those two processes work in 2 steps substantially reduces the probability of transferring or renouncing ownership of the contract by accident.
 
 ## Motivation
 <!--The motivation is critical for LIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
-When ownership of a contract is transferred in a single transaction, the new owner has no choice in wanting to own the contract or not. He is forced to own the contract once the transaction has been completed.
+The particular issue that this implementation of [EIP173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) solves is the irreversible nature of transferring or renouncing ownership of a contract.
 
-Making transfer of ownership a two-step process enables to give a choice for the new owner in deciding if he wants to become the owner of the contract or not.
-
-Finally, transferring ownership of the contract in a single transaction does not guarantee that the address behind the new owner (EOA or contract) is controlled. For instance, if the new owner lost its private key or if the new owner is a contract that is in a locked state.
+Transferring ownership of the contract in a single transaction does not guarantee that the address behind the new owner (EOA or contract) is controlled. For instance, if the new owner lost its private key or if the new owner is a contract that is in a locked state.
 
 Letting the new owner accept ownership of the contract guarantees that the contract is owned by an address (EOA or contract) that can be controlled, and that control over the contract implementing LSP14 will not be lost.
 
+Making transfer of ownership a two-step process also enables to give a choice for the new owner in deciding if he wants to become the owner of the contract or not.
 
 
 ## Specification
@@ -65,7 +62,7 @@ Returns the `address` of the upcoming new owner that was initiated by the curren
 *Requirements:*
 
 - MUST be `address(0)` if no ownership transfer is in progress.
-- MUST be set when transferring ownership of the contract via `transferOwnership(address)` to a new `address`.
+- MUST be set to a new `address` when transferring ownership of the contract via `transferOwnership(address)`.
 - SHOULD be cleared once the [`pendingOwner()`](#pendingowner) has accepted ownership of the contract.
 
 
@@ -82,8 +79,6 @@ MUST emit a [`OwnershipTransferredStarted`](#ownershiptransferstarted) event onc
 *Requirements:*
 
 - MUST only be called by the current `owner()` of the contract.
-- The `newOwner` MUST NOT be the contract itself `address(this)`
-
 
 #### acceptOwnership
 
@@ -108,7 +103,7 @@ MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#spec
 function renounceOwnership() public;
 ```
 
-Leaves the contract without an owner. Once ownership of the contract is renounced, it MUST NOT be possible to call the functions restricted to the owner only.
+Leaves the contract without an owner. Once ownership of the contract is renounced, it MUST NOT be possible to call functions restricted to the owner only.
 
 Since renouncing ownership is a sensitive operation, it SHOULD be done as a two step process by calling  `renounceOwnership(..)` twice. First to initiate the process, second as a confirmation.
 
@@ -119,31 +114,40 @@ MUST emit [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specif
 
 - MUST be called only by the `owner()` only.
 - The second call MUST happen AFTER the delay of 100 blocks and within the next 100 blocks from the first `renounceOwnership(..)` call.
-- If the 200 block has passed, the `renounceOwnership(..)` call phase SHOULD reset the process, and a new one will be initated.
+- If 200 blocks have passed, the `renounceOwnership(..)` call phase SHOULD reset the process, and a new one will be initated.
 
 ### Events
 
 #### OwnershipTransferStarted
 
 ```solidity
-event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+event OwnershipTransferStarted(address indexed currentOwner, address indexed newOwner);
 ```
 
 MUST be emitted when the process of transferring owhership of the contract is initiated.
 
 _Values:_
 
-- `previousOwner` Address of the current owner of the conract that implements LSP14.
+- `currentOwner` Address of the current owner of the contract that implements LSP14.
 
-- `newOwner` Address that will receive ownership of the contract that implemets LSP14. 
+- `newOwner` Address that will receive ownership of the contract that implements LSP14. 
 
-#### RenounceOwnershipInitiated
+#### RenounceOwnershipStarted
 
 ```solidity
-event RenounceOwnershipInitiated();
+event RenounceOwnershipStarted();
 ```
 
 MUST be emitted when the process of renouncing ownership of the contract is initiated.
+
+
+#### OwnershipTransferred
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+```
+
+MUST be emitted when ownership of the contract has been transferred.
 
 ### Hooks
 

--- a/LSPs/LSP-14-Ownable2Step.md
+++ b/LSPs/LSP-14-Ownable2Step.md
@@ -1,0 +1,187 @@
+---
+lip: 14
+title: Ownable2Step
+author:  
+discussions-to: https://discord.gg/E2rJPP4
+status: Draft
+type: LSP
+created: 2022-09-23
+requires: ERC173
+---
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the LIP.-->
+This contract describes a version of [EIP173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md), it being different by making the process of transferring ownership and renouncing ownership a 2-step process instead of instant execution.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+The particular issue that this implementation of [EIP173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) solves is the irreversible nature of transferring or renouncing ownership of a contract. Because owning the contract allows you to have access to sensitive methods, transferring or renouncing ownership of the contract by accident in a single transaction can be highly dangerous. Having those two processes work in 2 steps will substantially reduce the probability of transferring or renouncing ownership of the contract by accident.
+
+## Motivation
+<!--The motivation is critical for LIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the LIP solves. LIP submissions without sufficient motivation may be rejected outright.-->
+
+
+## Specification
+
+[ERC165] interface id: `0x94be5999`
+
+_This interface id can be used to detect Ownable2Step contracts._
+
+### Methods
+
+Contains the methods from:
+- [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable). *See below for details*
+
+#### owner
+
+```solidity
+function owner() external view returns (address);
+```
+
+Returns the `address` of the current contract owner.
+
+#### pendingOwner
+
+```solidity
+function pendingOwner() external view returns (address);
+```
+
+Return the `address` of the pending owner, of a ownership transfer, that was initiated with `transferOwnership(address)`. MUST be `address(0)` if no ownership transfer is in progress.
+
+MUST be set when transferring ownership of the contract via `transferOwnership(address)` to a new `address`.
+
+SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
+
+
+#### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external;
+```
+
+Sets the `newOwner` as `pendingOwner`.
+
+MUST be called only by `owner()`.
+
+The `newOwner` MUST NOT be the contract itself `address(this)`
+
+#### acceptOwnership
+
+```solidity
+function acceptOwnership() external;
+```
+
+Allow an `address` to become the new owner of the contract. MUST only be called by the pending owner.
+
+MUST be called after `transferOwnership` by the current `pendingOwner` to finalize the ownership transfer.
+
+MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event once the new owner has claimed ownership of the contract.
+
+#### renounceOwnership
+
+```solidity
+function renounceOwnership() public;
+```
+
+Leaves the contract without an owner. Once ownership of the contract is renounced, it MUST NOT be possible to call the functions restricted to the owner only.
+
+Since renouncing ownership is a sensitive operation, it SHOULD be done as a two step process by calling  `renounceOwnership(..)` twice. First to initiate the process, second as a confirmation.
+
+*Requirements:*
+
+- MUST be called only by the `owner()` only.
+- The second call MUST happen AFTER the delay of 100 blocks and within the next 100 blocks from the first `renounceOwnership(..)` call.
+- If the 200 block has passed, the `renounceOwnership(..)` call phase SHOULD reset the process, and a new one will be initated.
+
+MUST emit a [`RenounceOwnershipInitiated`](#renounceownershipinitiated) event on the first `renounceOwnership(..)` call.
+MUST emit [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event after successfully renouncing the ownership.
+
+### Events
+
+#### OwnershipTransferStarted
+
+```solidity
+event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+```
+
+MUST be emitted when the process of transferring owhership of the contract is initiated.
+
+_Values:_
+
+- `previousOwner` Address of the current owner of the conract that implements LSP14.
+
+- `newOwner` Address that will receive ownership of the contract that implemets LSP14. 
+
+#### RenounceOwnershipInitiated
+
+```solidity
+event RenounceOwnershipInitiated();
+```
+
+MUST be emitted when the process of renouncing ownership of the contract is initiated.
+
+### Hooks
+
+Every contract that supports the LSP14 standard SHOULD implement these hooks:
+
+#### _notifyUniversalReceiver
+
+```solidity
+function _notifyUniversalReceiver(
+    address universalReceiver,
+    bytes32 typeId,
+    bytes memory data
+)
+```
+
+Calls the `universalReceiver(..)` function on the `universalReceiver` address in the following situations:
+
+- When transferring ownership to the new owner, if the new owner address supports LSP1 InterfaceID, with the parameters below:
+
+    - `typeId`: keccak256('LSP14OwnershipTransferStarted')
+    - `data`: TBD
+
+- When accepting ownership by the new owner, if the old owner address supports LSP1 InterfaceID, with the parameters below:
+
+    - `typeId`: keccak256('LSP14OwnershipTransferred_SenderNotification')
+    - `data`: TBD
+
+- When accepting ownership by the new owner, if the new owner address supports LSP1 InterfaceID, with the parameters below:
+
+    - `typeId`: keccak256('LSP14OwnershipTransferred_RecipientNotification')
+    - `data`: TBD
+
+
+## Interface Cheat Sheet
+
+```solidity
+interface ILSP14  /* is ERC173 */ {
+         
+
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+    
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    event RenounceOwnershipInitiated();
+
+
+    function owner() external view returns (address);
+    
+    function pendingOwner() external view returns (address);
+
+    function transferOwnership(address newOwner) external; // onlyOwner
+
+    function acceptOwnership() external;
+    
+    function renounceOwnership() external; // onlyOwner
+
+}
+```
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[ERC165]: <https://eips.ethereum.org/EIPS/eip-165>
+[LSP1-UniversalReceiver]: <./LSP-1-UniversalReceiver.md>
+[LSP2-ERC725YJSONSchema]: <./LSP-2-ERC725YJSONSchema.md>

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -71,6 +71,14 @@ See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
 **Contains the methods from** [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor) with overriding:
 
+#### transferOwnership
+
+Similar to [`transferOwnership(address)`](./LSP-14-Ownable2Step.md#transferownership) from LSP14.
+
+**Additional requirements:**
+
+- The `newOwner` MUST NOT be the contract itself `address(this)`.
+
 #### execute
 
 ```solidity
@@ -96,7 +104,7 @@ Check [`execute(...)`](https://github.com/ERC725Alliance/ERC725/blob/develop/doc
 **Contains the methods from:**
 
 - [LSP1](./LSP-1-UniversalReceiver.md#specification)
-- [LLSP14](./LSP-14-Ownable2Step.md#specification)
+- [LSP14](./LSP-14-Ownable2Step.md#specification)
 
 ### Events
 
@@ -190,6 +198,8 @@ interface ILSP9  /* is ERC165 */ {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     event RenounceOwnershipInitiated();
+
+    event OwnershipRenounced();
 
 
     function owner() external view returns (address);

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -104,7 +104,7 @@ Check [`execute(...)`](https://github.com/ERC725Alliance/ERC725/blob/develop/doc
 function transferOwnership(address newOwner) external;
 ```
 
-Similar to [`transferOwnership(address)`](./LSP-14-Ownable2Step.md#transferownership) from LSP14.
+This function is part of the [LSP14]((./LSP-14-Ownable2Step.md#transferownership)) Specification, with additional requirements as follows:
 
 **Additional requirements:**
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -6,7 +6,7 @@ discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2021-09-21
-requires: LSP1, LSP2, LSP14, ERC165, ERC725X, ERC725Y
+requires: ERC165, ERC725X, ERC725Y, LSP1, LSP2, LSP14
 ---
 
 
@@ -71,14 +71,6 @@ See the [Interface Cheat Sheet](#interface-cheat-sheet) for details.
 
 **Contains the methods from** [ERC725](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#specification) (General data key-value store, and general executor) with overriding:
 
-#### transferOwnership
-
-Similar to [`transferOwnership(address)`](./LSP-14-Ownable2Step.md#transferownership) from LSP14.
-
-**Additional requirements:**
-
-- The `newOwner` MUST NOT be the contract itself `address(this)`.
-
 #### execute
 
 ```solidity
@@ -105,6 +97,18 @@ Check [`execute(...)`](https://github.com/ERC725Alliance/ERC725/blob/develop/doc
 
 - [LSP1](./LSP-1-UniversalReceiver.md#specification)
 - [LSP14](./LSP-14-Ownable2Step.md#specification)
+
+#### transferOwnership
+
+```solidity
+function transferOwnership(address newOwner) external;
+```
+
+Similar to [`transferOwnership(address)`](./LSP-14-Ownable2Step.md#transferownership) from LSP14.
+
+**Additional requirements:**
+
+- The `newOwner` MUST NOT be the contract itself `address(this)`.
 
 ### Events
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -6,7 +6,7 @@ discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2021-09-21
-requires: LSP1, LSP2, ERC165, ERC173, ERC725X, ERC725Y
+requires: LSP1, LSP2, LSP14, ERC165, ERC725X, ERC725Y
 ---
 
 
@@ -24,7 +24,7 @@ This standard defines a vault that can hold assets and interact with other contr
 
 ## Specification
 
-[ERC165] interface id: `0xfd4d5c50`
+[ERC165] interface id: `0xca86ec0f`
 
 _This interface id can be used to detect Vault contracts._
 
@@ -96,71 +96,7 @@ Check [`execute(...)`](https://github.com/ERC725Alliance/ERC725/blob/develop/doc
 **Contains the methods from:**
 
 - [LSP1](./LSP-1-UniversalReceiver.md#specification)
-- Claim Ownership, a modified version of [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md#specification) (Ownable). *See below for details*
-
-#### owner
-
-```solidity
-function owner() external view returns (address);
-```
-
-Returns the `address` of the current contract owner.
-
-#### pendingOwner
-
-```solidity
-function pendingOwner() external view returns (address);
-```
-
-Return the `address` of the pending owner, of a ownership transfer, that was initiated with `transferOwnership(address)`. MUST be `address(0)` if no ownership transfer is in progress.
-
-MUST be set when transferring ownership of the contract via `transferOwnership(address)` to a new `address`.
-
-SHOULD be cleared once the [`pendingOwner`](#pendingowner) has claim ownership of the contract.
-
-
-#### transferOwnership
-
-```solidity
-function transferOwnership(address newOwner) external;
-```
-
-Sets the `newOwner` as `pendingOwner`.
-
-MUST be called only by `owner()`.
-
-The `newOwner` MUST NOT be the contract itself `address(this)`
-
-#### claimOwnership
-
-```solidity
-function claimOwnership() external;
-```
-
-Allow an `address` to become the new owner of the contract. MUST only be called by the pending owner.
-
-MUST be called after `transferOwnership` by the current `pendingOwner` to finalize the ownership transfer.
-
-MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event once the new owner has claimed ownership of the contract.
-
-#### renounceOwnership
-
-```solidity
-function renounceOwnership() public;
-```
-
-Leaves the contract without an owner. Once ownership of the contract is renounced, it MUST NOT be possible to call the functions restricted to the owner only.
-
-Since renouncing ownership is a sensitive operation, it SHOULD be done as a two step process by calling  `renounceOwnership(..)` twice. First to initiate the process, second as a confirmation.
-
-*Requirements:*
-
-- MUST be called only by the `owner()` only.
-- The second call MUST happen AFTER the delay of 100 blocks and within the next 100 blocks from the first `renounceOwnership(..)` call.
-- If the 200 block has passed, the `renounceOwnership(..)` call phase SHOULD reset the process, and a new one will be initated.
-
-MUST emit a [`RenounceOwnershipInitiated`](#renounceownershipinitiated) event on the first `renounceOwnership(..)` call.
-MUST emit [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#specification) event after successfully renouncing the ownership.
+- [LLSP14](./LSP-14-Ownable2Step.md#specification)
 
 ### Events
 
@@ -171,33 +107,6 @@ event ValueReceived(address indexed sender, uint256 indexed value);
 ```
 
 MUST be emitted when a native token transfer was received.
-
-#### RenounceOwnershipInitiated
-
-```solidity
-event RenounceOwnershipInitiated();
-```
-
-MUST be emitted when renouncing ownership of the contract is initiated.
-
-### Hooks
-
-Every contract that supports the LSP9 standard SHOULD implement these hooks:
-
-#### _notifyVaultSender
-
-Calls the `universalReceiver(..)` function on the old owner address when claiming ownership by the new owner, if the old owner address supports LSP1 InterfaceID, with the parameters below:
-
-- `typeId`: keccak256('LSP9VaultSender')
-- `data`: TBD
-
-#### _notifyVaultReceiver
-
-Calls the `universalReceiver(..)` function on the new owner address after claiming ownership, if it supports LSP1 InterfaceID, with the parameters below:
-
-- `typeId`: keccak256('LSP9VaultRecipient')
-- `data`: TBD
-
 
 ## Rationale
 
@@ -232,24 +141,7 @@ ERC725Y JSON Schema:
 
 ```solidity
 
-interface ILSP9  /* is ERC165 */ {
-       
-    
-    // Modified ERC173 (ClaimOwnership)
-    
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
-
-    function owner() external view returns (address);
-    
-    function pendingOwner() external view returns (address);
-
-    function transferOwnership(address newOwner) external; // onlyOwner
-
-    function claimOwnership() external;
-    
-    function renounceOwnership() external; // onlyOwner
-        
+interface ILSP9  /* is ERC165 */ {    
 
     
     // ERC725X
@@ -289,6 +181,26 @@ interface ILSP9  /* is ERC165 */ {
     event ValueReceived(address indexed sender, uint256 indexed value);
 
     fallback() external payable;
+
+
+    // LSP14
+
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    event RenounceOwnershipInitiated();
+
+
+    function owner() external view returns (address);
+    
+    function pendingOwner() external view returns (address);
+
+    function transferOwnership(address newOwner) external; // onlyOwner
+
+    function acceptOwnership() external;
+    
+    function renounceOwnership() external; // onlyOwner
 
 }
 


### PR DESCRIPTION
## What does this PR introduce?

This PR introduces LSP14Ownable2Step, an LSP focused towards the following processes:
- owning a contract
- transferring ownership of a contract
- renouncing ownership of a contract

Introduced features:
- Transfer ownership in 2 steps.
- Renounce ownership in 2 steps.
- Notify the new owner whenever the first step of transfer ownership is executed.
- Notify both the old owner and the new owner whenever the process of transferring ownership is complete.