### PR TITLE
feat: LSP4 Metadata with custom attributes

### DIFF
--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -98,6 +98,7 @@ The linked JSON file SHOULD have the following format:
 ```js
 {
     "LSP4Metadata": {
+        "name": "string", // name of the DigitalAsset if not defined in LSP4TokenName
         "description": "string",
         "links": [ // links related to DigitalAsset
             {
@@ -134,7 +135,14 @@ The linked JSON file SHOULD have the following format:
             "hash": 'string',
             "url": 'string',
             "fileType": 'string'
-        }]  
+        }],
+        "attributes": [
+        {
+            "key": "string",    // name of the attribute
+            "value": "string", // value assigned to the attribute
+            "type": "string | number | boolean",   // for encoding/decoding purposes
+        },
+        ...
     }
 }
 ```
@@ -176,7 +184,24 @@ Example:
             hash: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
             url: 'ifps://QmPJESHbVkPtSaHntNVY5F6JDLW8v69M2d6khXEYGUMn7N',
             fileType: 'fbx'
-        }]  
+        }],
+        attributes: [
+            {
+                key: 'Standard type',
+                value: 'LSP',
+                type: "string"
+            },
+            {
+                key: 'Standard number',
+                value: 4,
+                type: "number"
+            },
+            {
+                key: '🆙',
+                value: true,
+                type: "boolean"
+            }
+        ]
     }
 }
 ```


### PR DESCRIPTION
Following the idea from the existing [OpenSea metadataStandard](https://docs.opensea.io/docs/metadata-standards#attributes), it would be interesting adding an area to have custom metadata related to assets. 

I kept the "attributes" wording (not sure about it though) naming but changed the "trait_type" for "key", for two reasons:
- Using Lukso, you're used to the term "key"
- It's not necessarily a trait, it's just some custom metadata
