### PR TITLE
Simplify LSP17ContractExtension Standard

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -74,6 +74,20 @@ This function is part of the [LSP17] specification, with additional requirements
 
 - MUST be payable.
 - MUST emit a [`ValueReceived`] event if value was present.
+- MUST return if the data sent to the contract is less than 4 bytes in length or if the first 4 bytes of the data are equal to 0.
+- MUST check for address of the extension under the following ERC725Y Data Key:
+
+```json
+{
+    "name": "LSP17Extension:<bytes4>",
+    "key": "0xcee78b4094da860110960000<bytes4>",
+    "keyType": "Mapping",
+    "valueType": "address",
+    "valueContent": "Address"
+}
+```
+
+> <bytes4\> is the `functionSelector` called on the account contract. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
 
 
 #### owner
@@ -250,7 +264,6 @@ MUST be emitted when a native token transfer was received.
 
 ### ERC725Y Data Keys
 
-
 #### LSP1UniversalReceiverDelegate
 
 ```json
@@ -299,7 +312,7 @@ Check [LSP1-UniversalReceiver] and [LSP2-ERC725YJSONSchema] for more information
 
 > <bytes4\> is the `functionSelector` called on the account contract. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
 
-If there is a function called on the account and the function does not exist, the fallback function lookup an address stored under the data key attached above and forwards the call to it with the value of the msg.sender and msg.value appended as extra calldata.
+If there is a function called on the account and the function does not exist, the fallback function lookup an address stored under the data key attached above and forwards the call to it with the value of the `msg.sender` and `msg.value` appended as extra calldata.
 
 Check [LSP17-ContractExtension] and [LSP2-ERC725YJSONSchema] for more information.
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -73,7 +73,7 @@ fallback() external payable;
 This function is part of the [LSP17] specification, with additional requirements as follows:
 
 - MUST be payable.
-- MUST emit a [`ValueReceived`] event if value was present.
+- MUST emit a [`ValueReceived`] event if value was sent alongside some calldata.
 - MUST return if the data sent to the contract is less than 4 bytes in length or if the first 4 bytes of the data are equal to 0.
 - MUST check for address of the extension under the following ERC725Y Data Key:
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -74,7 +74,7 @@ This function is part of the [LSP17] specification, with additional requirements
 
 - MUST be payable.
 - MUST emit a [`ValueReceived`] event if value was sent alongside some calldata.
-- MUST return if the data sent to the contract is less than 4 bytes in length or if the first 4 bytes of the data are equal to 0.
+- MUST return if the data sent to the contract is less than 4 bytes in length or if the first 4 bytes of the data are equal to `0x00000000`.
 - MUST check for address of the extension under the following ERC725Y Data Key:
 
 ```json

--- a/LSPs/LSP-17-ContractExtension.md
+++ b/LSPs/LSP-17-ContractExtension.md
@@ -6,32 +6,31 @@ discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2021-11-19
-requires: ERC725Y
+requires: ERC165
 ---
-
 
 ## Simple Summary
 
-This standard describes a way to extend contract's functionalities even after deployment by forwarding the call to extension contracts.
+This standard describes a mechanism for adding additional functionality to a contract after it has been deployed, through the use of extensions.
  
 ## Abstract
 
 This proposal defines two types of contracts:
+
 - an extendable contract which functionalities are extended.
-- an extension contract that extend the functionalities of the extendable contract.
+- an extension contract which contains the functionality that will be added to the extendable contract.
 
-When the extendable contract receives a call for a function not implemented in its public interface, it can forward this call to an extension contract. This forwarding occurs through the fallback function. The extension contract can then receive the calldata of the initial message call, appended with the `msg.sender` and the `msg.value` initially received.
+When the extendable contract is called with a function that is not part of its public interface, it can forward this call to an extension contract, through the use of its fallback function.
 
-The extendable contract should map function selectors (bytes4) to extension contract addresses that implement these functions being called.
+The extension contract function is able to access the original `msg.sender` and `msg.value` of the extendable contract by appending them to the calldata of the call to the extension.
+
+The extendable contract SHOULD map function selectors to extension contract addresses that handle those functions.
 
 ## Motivation
 
-After deploying a contract, there is no possible way to add new native functions into the bytecode of the deployed contract. This represents a limitation for smart contracts, for instance, with smart contract-based accounts that could evolve over time and need specific functions to support future usecases and standards.
+After deploying a smart contract to the network, it is not possible to add new functionalities to it. This limitation is significant for smart contracts that aim to support a wider range of functionalities, especially those that may be standardized in the future.
 
-The extensions added can be removed or replaced in any time in the future making the extendable contract highly customizable and able to suit any behavior needed. 
-
-The contracts applying the extendable logic can re-use deployed extensions contract. Instead of mass deploying contracts to the blockchain with the same logic that are already existing on the blockchain, extensions contract can be re-used by extendable contract.
-
+Implementing a mechanism for attaching extensions to a specific contract not only makes the contract more extendable and able to support a wider range of functionalities over time, but it also enables the reusability of extensions across multiple contracts. This reduces the need for deploying multiple contracts with the same logic to the blockchain network, thus potentially decreasing chain congestion and reducing gas costs.
 
 ## LSP17Extendable Specification
 
@@ -39,50 +38,18 @@ The contracts applying the extendable logic can re-use deployed extensions contr
 
 _This `bytes4` interface id is calculated as the first 4 bytes of the keccak256 of the word "LSP17Extendable" since there is no public functions available._
 
-Smart contracts implementing the LSP17Extendable standard MUST implement the [ERC165] `supportsInterface(..)` function and MUST support the LSP17Extendable interface id.
+Smart contracts that adhere to the LSP17Extendable standard MUST include the `supportsInterface(..)` function, as specified in the [ERC165] standard, and MUST support the LSP17Extendable interfaceId.
 
-
-### Overview
+They SHOULD also check whether the interface being queried is supported within the `supportsInterface(..)` extension, if it exists.
 
 Whenever a function is called on an extendable contract and the function does not exist, the fallback function of the extendable contract MUST call the function on the extension mapped using the `CALL` opcode. The calldata MUST be appended with 52 extra bytes as follows:
 
 - The `msg.sender` calling the extendable contract without any pad, MUST be 20 bytes.
 - The `msg.value` received to the extendable contract, MUST be 32 bytes.
 
+The standard does not enforce a specific method for mapping function selectors to the addresses of the extension contracts, nor does it require specific methods for setting and querying the addresses of the extensions.
 
-If the extendable contract supports [ERC725Y], the extension address MUST be stored under the data key attached below:
-
-```json
-{
-    "name": "LSP17Extension:<bytes4>",
-    "key": "0xcee78b4094da860110960000<bytes4>",
-    "keyType": "Mapping",
-    "valueType": "address",
-    "valueContent": "Address"
-}
-```
-
-> <bytes4\> is the `functionSelector` called on the account contract. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
-
-The [DataChanged] event MUST be emitted whenever an extension is added/changed/removed.
-
-The LSP17ContractExtension does not enforce a specific way to store the extension address based on the bytes4 function selector. As an example, a mapping from function selectors to extensions, (eg: `mapping(bytes4 => address)`) can be used, but any other data structure can be used to map function selector to extension contract addresses.
-
-If the extendable contract does not support ERC725Y, the [ExtensionChanged] event MUST be emitted whenever an extension is added/changed/removed.
-
-### Events
-
-#### ExtensionChanged
-
-```solidity
-event ExtensionChanged(bytes4 indexed functionSelector, address indexed extension);
-```
-
-MUST be emitted when an extension is added/changed/removed.
-
-> In case the extendable contract supports [ERC725Y], there is no need to emit the ExtensionChanged event.
-
-
+As an example, a mapping of function selectors to extension contracts can be used, such as a `mapping(bytes4 => address)`. However, any other data structure can also be used to map function selectors to extension contract addresses.
 
 ## LSP17Extension Specification
 
@@ -90,12 +57,13 @@ MUST be emitted when an extension is added/changed/removed.
 
 _This `bytes4` interface id is calculated as the first 4 bytes of the keccak256 of the word "LSP17Extension" since there is no public functions available._
 
-Smart contracts implementing the LSP17Extension standard MUST implement the [ERC165] `supportsInterface(..)` function and MUST support the LSP17Extension interface id.
-
+Smart contracts that adhere to the LSP17Extension standard MUST include the `supportsInterface(..)` function, as specified in the [ERC165] standard, and MUST support the LSP17Extension interfaceId.
 
 ### Overview
 
-Normally, some contract functions operates on validation of `msg.sender` and `msg.value` which are accessibe using global variables in solidity. Given the fact that the extendable contract will call the extension using the [CALL] opcode, the `msg.sender` on the extension contract will be the address of the extendable contract. The `msg.sender` of the extendable contract and the `msg.value` sent to the extendable contract will be appended as extra calldata sent to the extension contract and can be retreived using these functions:
+Normally, contract functions use `msg.sender` and `msg.value` global variables for validation in Solidity. However, when an extendable contract calls an extension using the CALL opcode, the `msg.sender` on the extension contract will always be the address of the extendable contract.
+
+To access the original `msg.sender` and `msg.value` sent to the extendable contract, the extendable contract will append them as extra calldata and extension contract can use the following functions to retrieve them within the extension:
 
 ```solidity
 function _extendableMsgSender() internal view virtual returns (address) {
@@ -117,8 +85,7 @@ function _extendableMsgData() internal view virtual returns (bytes memory) {
 }
 ```
 
-The validation mechanism should be diffferent for extensions, and depend on these variables not on the `msg.sender` and `msg.value` globally accessible from the extension.
-
+If a validation mechanism exists in the extension contract, it should depend on the `_extendableMsgSender()`, `_extendableMsgValue()` or `_extendableMsgData()` functions instead of the `msg.sender` and `msg.value` global variables, as anyone can call the extendable contract and trigger a call to the extensions.
 
 ## Security Considerations
 
@@ -126,7 +93,13 @@ A function selector clash can occurs when two different function signatures hash
 
 ## Rationale
 
+The design of this standard was inspired by [EIP-2535 Diamonds, Multi-Facet Proxy], which also proposes a way to add functionality to a smart contract through the use of facets (extensions). However, EIP-2535 uses the DELEGATECALL opcode to execute the function on the extension contract, allowing it to access the storage of the extendable contract.
 
+This proposal, on the other hand, uses the CALL opcode to forward the function call to the extension contract. This design decision was made to enhance security by mitigating the risk of malicious actors exploiting the selfdestruct functionality or altering the storage of the extendable contract.
+
+By appending the `msg.sender` and `msg.value` to the calldata when forwarding the function call from the extendable to the extension contract, this proposal allows the extension contract to know the address of the caller and the value associated with the call.
+
+This design decision ensures that the extension contract can maintain context of the original call and allows the extension contract to make proper decisions based on the call context.
 
 ## Implementation
 
@@ -137,5 +110,4 @@ An implementation can be found in the [lukso-network/lsp-smart-contracts](https:
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 [ERC165]: <https://eips.ethereum.org/EIPS/eip-165>
-[LSP1-UniversalReceiver]: <./LSP-1-UniversalReceiver.md>
-[LSP2-ERC725YJSONSchema]: <./LSP-2-ERC725YJSONSchema.md>
+[EIP-2535 Diamonds, Multi-Facet Proxy]: <https://eips.ethereum.org/EIPS/eip-2535>

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -56,7 +56,7 @@ fallback() external payable;
 This function is part of the [LSP17] specification, with additional requirements as follows:
 
 - MUST be payable.
-- MUST emit a [`ValueReceived`] event if value was present.
+- MUST emit a [`ValueReceived`] event if value was sent alongside some calldata.
 - MUST return if the data sent to the contract is less than 4 bytes in length or if the first 4 bytes of the data are equal to 0.
 - MUST check for address of the extension under the following ERC725Y Data Key:
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -57,6 +57,20 @@ This function is part of the [LSP17] specification, with additional requirements
 
 - MUST be payable.
 - MUST emit a [`ValueReceived`] event if value was present.
+- MUST return if the data sent to the contract is less than 4 bytes in length or if the first 4 bytes of the data are equal to 0.
+- MUST check for address of the extension under the following ERC725Y Data Key:
+
+```json
+{
+    "name": "LSP17Extension:<bytes4>",
+    "key": "0xcee78b4094da860110960000<bytes4>",
+    "keyType": "Mapping",
+    "valueType": "address",
+    "valueContent": "Address"
+}
+```
+
+> <bytes4\> is the `functionSelector` called on the vault contract. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
 
 
 #### owner
@@ -280,7 +294,7 @@ Check [LSP1-UniversalReceiver] and [LSP2-ERC725YJSONSchema] for more information
 
 > <bytes4\> is the `functionSelector` called on the vault contract. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
 
-If there is a function called on the vault and the function does not exist, the fallback function lookup an address stored under the data key attached above and forwards the call to it with the value of the msg.sender and msg.value appended as extra calldata.
+If there is a function called on the account and the function does not exist, the fallback function lookup an address stored under the data key attached above and forwards the call to it with the value of the `msg.sender` and `msg.value` appended as extra calldata.
 
 Check [LSP17-ContractExtension] and [LSP2-ERC725YJSONSchema] for more information.
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -294,7 +294,7 @@ Check [LSP1-UniversalReceiver] and [LSP2-ERC725YJSONSchema] for more information
 
 > <bytes4\> is the `functionSelector` called on the vault contract. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
 
-If there is a function called on the account and the function does not exist, the fallback function lookup an address stored under the data key attached above and forwards the call to it with the value of the `msg.sender` and `msg.value` appended as extra calldata.
+If there is a function called on the vault and the function does not exist, the fallback function lookup an address stored under the data key attached above and forwards the call to it with the value of the `msg.sender` and `msg.value` appended as extra calldata.
 
 Check [LSP17-ContractExtension] and [LSP2-ERC725YJSONSchema] for more information.
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -57,7 +57,7 @@ This function is part of the [LSP17] specification, with additional requirements
 
 - MUST be payable.
 - MUST emit a [`ValueReceived`] event if value was sent alongside some calldata.
-- MUST return if the data sent to the contract is less than 4 bytes in length or if the first 4 bytes of the data are equal to 0.
+- MUST return if the data sent to the contract is less than 4 bytes in length or if the first 4 bytes of the data are equal to `0x00000000`.
 - MUST check for address of the extension under the following ERC725Y Data Key:
 
 ```json


### PR DESCRIPTION
## What does this PR introduce ?

- Simplify the LSP17ContractExtension by not enforcing any behavior of storing selectors to addresses, events, talking about ERC725Y , etc ..
- Update different sections, Rational, Motivation, Abstract.
- Add the modification requirements in LSP0 and LSP9 