### PR TITLE
Document LSP14 Type IDs overriding

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -102,6 +102,10 @@ function transferOwnership(address newPendingOwner) external;
 
 This function is part of the [LSP14] specification.
 
+- MUST override the LSP14 Type ID triggered by using `transferOwnership(..)` to the one below:
+
+    - `keccak256('LSP0OwnershipTransferStarted')` > `0xe17117c9d2665d1dbeb479ed8058bbebde3c50ac50e2e65619f60006caac6926`
+
 #### acceptOwnership
 
 ```solidity
@@ -110,6 +114,11 @@ function acceptOwnership() external;
 
 This function is part of the [LSP14] specification.
 
+- MUST override the LSP14 Type IDs triggered by using `accceptOwnership(..)` to the ones below:
+
+    - `keccak256('LSP0OwnershipTransferred_SenderNotification')` > `0xa4e59c931d14f7c8a7a35027f92ee40b5f2886b9fdcdb78f30bc5ecce5a2f814`
+    
+    - `keccak256('LSP0OwnershipTransferred_RecipientNotification')` > `0xceca317f109c43507871523e82dc2a3cc64dfa18f12da0b6db14f6e23f995538`
 
 #### renounceOwnership
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -100,7 +100,7 @@ This function is part of the [LSP14] specification.
 function transferOwnership(address newPendingOwner) external;
 ```
 
-This function is part of the [LSP14] specification.
+This function is part of the [LSP14] specification, with additional requirements as follows:
 
 - MUST override the LSP14 Type ID triggered by using `transferOwnership(..)` to the one below:
 
@@ -112,7 +112,7 @@ This function is part of the [LSP14] specification.
 function acceptOwnership() external;
 ```
 
-This function is part of the [LSP14] specification.
+This function is part of the [LSP14] specification, with additional requirements as follows:
 
 - MUST override the LSP14 Type IDs triggered by using `accceptOwnership(..)` to the ones below:
 

--- a/LSPs/LSP-14-Ownable2Step.md
+++ b/LSPs/LSP-14-Ownable2Step.md
@@ -86,7 +86,7 @@ MUST emit a [`OwnershipTransferredStarted`](#ownershiptransferstarted) event onc
     - `typeId`: `keccak256('LSP14OwnershipTransferStarted')` > `0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0`
     - `data`: TBD
 
-The Type ID associated with this hook COULD be altered in a contract that inherits from LSP14. This allows for more straightforward identification of the contract whose ownership is being transferred. Example where the LSP14 type ID is overriden can be found in [LSP0](LSP-0-ERC725Account.md#transferownership) and [LSP9](LSP-9-Vault.md#transferownership)
+The Type ID associated with this hook COULD be altered in a contract that inherits from LSP14. This allows for more straightforward identification of the contract whose ownership is being transferred. Example where the LSP14 type ID is overriden can be found in [LSP0](LSP-0-ERC725Account.md#transferownership) and [LSP9](LSP-9-Vault.md#transferownership) standards.
 
 #### acceptOwnership
 

--- a/LSPs/LSP-14-Ownable2Step.md
+++ b/LSPs/LSP-14-Ownable2Step.md
@@ -81,10 +81,12 @@ MUST emit a [`OwnershipTransferredStarted`](#ownershiptransferstarted) event onc
 
 **LSP1 Hooks:**
 
-- If the new owner address supports LSP1 interface, SHOULD call the new owner's [`universalReceiver(...)`] function with the following parameters below:
+- If the new owner address supports LSP1 interface, SHOULD call the new owner's [`universalReceiver(...)`] function with the default parameters below:
 
     - `typeId`: `keccak256('LSP14OwnershipTransferStarted')` > `0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0`
     - `data`: TBD
+
+The Type ID associated with this hook can be altered in a contract that inherits from LSP14. This allows for more straightforward identification of the contract whose ownership is being transferred. Example implementation can be found in [LSP0](LSP-0-ERC725Account.md#transferownership) and [LSP9](LSP-9-Vault.md#transferownership)
 
 #### acceptOwnership
 
@@ -104,16 +106,17 @@ MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#spec
 
 **LSP1 Hooks:**
 
-- If the previous owner is a contract that supports LSP1 interface, SHOULD call the previous owner's [`universalReceiver(...)`] function with the parameters below:
+- If the previous owner is a contract that supports LSP1 interface, SHOULD call the previous owner's [`universalReceiver(...)`] function with the default parameters below:
 
     - `typeId`: `keccak256('LSP14OwnershipTransferred_SenderNotification')` > `0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c`
     - `data`: TBD
 
-- If the new owner is a contract that supports LSP1 interface, SHOULD call the new owner's [`universalReceiver(...)`] function with the parameters below:
+- If the new owner is a contract that supports LSP1 interface, SHOULD call the new owner's [`universalReceiver(...)`] function with the default parameters below:
 
     - `typeId`: `keccak256('LSP14OwnershipTransferred_RecipientNotification')` > `0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c`
     - `data`: TBD
 
+The Type IDs associated with this hooks can be altered in a contract that inherits from LSP14. This allows for more straightforward identification of the contract whose ownership is being transferred. Example implementation can be found in [LSP0](LSP-0-ERC725Account.md#acceptownerhsip) and [LSP9](LSP-9-Vault.md#acceptownership)
 
 #### renounceOwnership
 

--- a/LSPs/LSP-14-Ownable2Step.md
+++ b/LSPs/LSP-14-Ownable2Step.md
@@ -86,7 +86,7 @@ MUST emit a [`OwnershipTransferredStarted`](#ownershiptransferstarted) event onc
     - `typeId`: `keccak256('LSP14OwnershipTransferStarted')` > `0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0`
     - `data`: TBD
 
-The Type ID associated with this hook can be altered in a contract that inherits from LSP14. This allows for more straightforward identification of the contract whose ownership is being transferred. Example implementation can be found in [LSP0](LSP-0-ERC725Account.md#transferownership) and [LSP9](LSP-9-Vault.md#transferownership)
+The Type ID associated with this hook COULD be altered in a contract that inherits from LSP14. This allows for more straightforward identification of the contract whose ownership is being transferred. Example where the LSP14 type ID is overriden can be found in [LSP0](LSP-0-ERC725Account.md#transferownership) and [LSP9](LSP-9-Vault.md#transferownership)
 
 #### acceptOwnership
 
@@ -116,7 +116,7 @@ MUST emit a [`OwnershipTransferred`](https://eips.ethereum.org/EIPS/eip-173#spec
     - `typeId`: `keccak256('LSP14OwnershipTransferred_RecipientNotification')` > `0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c`
     - `data`: TBD
 
-The Type IDs associated with this hooks can be altered in a contract that inherits from LSP14. This allows for more straightforward identification of the contract whose ownership is being transferred. Example implementation can be found in [LSP0](LSP-0-ERC725Account.md#acceptownerhsip) and [LSP9](LSP-9-Vault.md#acceptownership)
+The Type IDs associated with these hooks can be altered in a contract that inherits from LSP14. This allows for more straightforward identification of the contract whose ownership is being transferred. Examples where the LSP14 type IDs are overriden can be found in the [LSP0](LSP-0-ERC725Account.md#acceptownerhsip) and [LSP9](LSP-9-Vault.md#acceptownership) standards.
 
 #### renounceOwnership
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -85,6 +85,10 @@ function transferOwnership(address newPendingOwner) external;
 
 This function is part of the [LSP14] specification.
 
+- MUST override the LSP14 Type ID triggered by using `transferOwnership(..)` to the one below:
+
+    - `keccak256('LSP0OwnershipTransferStarted')` > `0xe17117c9d2665d1dbeb479ed8058bbebde3c50ac50e2e65619f60006caac6926`
+
 #### acceptOwnership
 
 ```solidity
@@ -93,6 +97,11 @@ function acceptOwnership() external;
 
 This function is part of the [LSP14] specification.
 
+- MUST override the LSP14 Type IDs triggered by using `accceptOwnership(..)` to the ones below:
+
+    - `keccak256('LSP0OwnershipTransferred_SenderNotification')` > `0xa4e59c931d14f7c8a7a35027f92ee40b5f2886b9fdcdb78f30bc5ecce5a2f814`
+    
+    - `keccak256('LSP0OwnershipTransferred_RecipientNotification')` > `0xceca317f109c43507871523e82dc2a3cc64dfa18f12da0b6db14f6e23f995538`
 
 #### renounceOwnership
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -83,7 +83,7 @@ This function is part of the [LSP14] specification.
 function transferOwnership(address newPendingOwner) external;
 ```
 
-This function is part of the [LSP14] specification.
+This function is part of the [LSP14] specification, with additional requirements as follows:
 
 - MUST override the LSP14 Type ID triggered by using `transferOwnership(..)` to the one below:
 
@@ -95,7 +95,7 @@ This function is part of the [LSP14] specification.
 function acceptOwnership() external;
 ```
 
-This function is part of the [LSP14] specification.
+This function is part of the [LSP14] specification, with additional requirements as follows:
 
 - MUST override the LSP14 Type IDs triggered by using `accceptOwnership(..)` to the ones below:
 


### PR DESCRIPTION
### What does this PR introduce?

In this PR the following changes are introduced:

- Adding a note in LSP14 about the possibility of overriding the Type IDs of the hooks called by `transferOwnership(..)` and `acceptOwnership(..)`
- Adding requirements in LSP0 and LSP9 about overriding the Type IDs in LSP14