### PR TITLE
chore: removed duplication of tokenId type explanations

### DIFF
--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -51,11 +51,6 @@ The LSP8TokenIdType metadata key provides this information and describes how to 
 
 The `tokenId` type can be one of the following possible enum values.
 
-
-- 1 -> `address`: another contract.
-- 2 -> `uint256`: a number, which may be an incrementing count where each minted token is assigned the next number.
-- 3 -> `bytes32`: a hashed value (ie. serial number).
-
 | Value | Type      | Description  |
 |:-----:|:---------:|--------------|
 | `1`   | `address` | each NFT is represented as its **own [ERC725Y] smart contract.** |


### PR DESCRIPTION
There was an incomplete duplication of **tokenId** types explanation. Looks like it's just something that was left from the older version of the LSP8 standard.

![Screenshot 2023-01-20 at 12 40 16](https://user-images.githubusercontent.com/36865532/213676385-d008127b-8ee5-4f05-854a-f2f1a7d7ce64.png)
