### PR TITLE
chore: added ERC173 to requirements of LSP-7

### DIFF
--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -6,7 +6,7 @@ discussions-to: https://discord.gg/E2rJPP4 (LUKSO), https://discord.gg/PQvJQtCV 
 status: Draft
 type: LSP
 created: 2021-09-02
-requires: ERC165, ERC725Y, LSP1, LSP2, LSP4
+requires: ERC165, ERC173, ERC725Y, LSP1, LSP2, LSP4
 ---
 
 <!--You can leave these HTML comments in your merged LIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new LIPs. Note that an LIP number will be assigned by an editor. When opening a pull request to submit your LIP, please use an abbreviated title in the filename, `lip-draft_title_abbrev.md`. The title should be 44 characters or less.-->


### PR DESCRIPTION
In the LSP-7 cheat sheet, the ERC173 is used amongst other standards, but it's not mentioned as a requirement in the `requires` column in the header.

![Screenshot 2023-02-28 at 10 52 12](https://user-images.githubusercontent.com/36865532/221803341-afe006fd-d6e5-4fb4-9a6e-a8b3a35909f3.png)
