### PR TITLE
Update LSP6 Specs with new behavior of AllowedCalls

### DIFF
--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -489,7 +489,7 @@ The full list of allowed calls MUST be constructed as a [CompactBytesArray](./LS
 > **NB:** the three dots `...` are placeholders for `<bytes4 restrictionOperations> <bytes20 allowedAddress> <bytes4 allowedInterfaceId> <bytes4 allowedFunction>` and used for brievity.
 
 - `0020`: **0020** in decimals is **32**, which is the sum of bytes length of the four elements below concatenated together.
-- `restrictionOperations`: A bitArray that represents the list of operations that the restrictions listed applies for.
+- `restrictionOperations`: A bitArray that represents the list of operations that the restrictions listed (address - interfaceId - function) applies for.
 
     The operations are defined with specific bits, starting from the 4th byte from the most right: 
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -314,7 +314,7 @@ BitArray representation: `0x0000000000000000000000000000000000000000000000000000
 
 BitArray representation: `0x0000000000000000000000000000000000000000000000000000000000000080`
 
-- Allows reentering the public [`execute(bytes)`](#execute), [`execute(uint256[],bytes[])`](#execute-array), [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall) and [`executeRelayCall(bytes[],uint256[],uint256[],bytes[])`](#executerelaycall-array) functions. 
+- Allows reentering the public [`execute(bytes)`](#execute), [`execute(uint256[],bytes[])`](#execute-array), [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall) and [`executeRelayCall(bytes[],uint256[],uint256[],bytes[])`](#executerelaycall-array) functions.
 
 
 #### `SUPER_TRANSFERVALUE`
@@ -382,7 +382,7 @@ BitArray representation: `0x0000000000000000000000000000000000000000000000000000
 
 BitArray representation: `0x0000000000000000000000000000000000000000000000000000000000010000`
 
-- Allows creating a contract with [CREATE] and [CREATE2] operations from the target contract through [`execute(..)`](./LSP-0-ERC725Account.md#execute) function of the target. To fund the contract created while deployment, the caller should have the SUPER_TRANSFERVALUE permission.
+- Allows creating a contract with [CREATE] and [CREATE2] operations from the target contract through [`execute(..)`](./LSP-0-ERC725Account.md#execute) function of the target.
 
 #### `SUPER_SETDATA`
 

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -472,7 +472,7 @@ Since the `valueType` of this data key is `bytes32`, up to 255 different permiss
     "key": "0x4b80742de2bf393a64c70000<address>",
     "keyType": "MappingWithGrouping",
     "valueType": "(bytes4,address,bytes4,bytes4)[CompactBytesArray]",
-    "valueContent": "(Bytes4,Address,Bytes4,Bytes4)"
+    "valueContent": "(BitArray,Address,Bytes4,Bytes4)"
 }
 ```
 
@@ -756,7 +756,7 @@ ERC725Y JSON Schema `LSP6KeyManager`, set at the target(#target) contract:
         "key": "0x4b80742de2bf393a64c70000<address>",
         "keyType": "MappingWithGrouping",
         "valueType": "(bytes4,address,bytes4,bytes4)[CompactBytesArray]",
-        "valueContent": "(Bytes4,Address,Bytes4,Bytes4)"
+        "valueContent": "(BitArray,Address,Bytes4,Bytes4)"
     },
     {
         "name": "AddressPermissions:AllowedERC725YDataKeys:<address>",


### PR DESCRIPTION
## What does this PR introduce ?

- Adding the new behavior of AllowedCalls where an additional bytes4 representing a bitArray was added to the AllowedCall dataKey.

A bitArray that represents the list of operations that the restrictions listed applies for.

    The operations are defined with specific bits, starting from the 4th byte from the most right: 

    - transferValue `00000001`
    - call `00000010`
    - staticcall `00000100`
    - delegatecall `00001000` 