### PR TITLE
[LSP4] Mark `LSP4TokenName` + `LSP4TokenSymbol` as OPTIONAL + add requirements if used

### DIFF
--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -46,7 +46,14 @@ The supported standard SHOULD be `LSP4DigitalAsset`
 
 #### LSP4TokenName
 
-A string representing the name for the token collection.
+A string representing the name of the token.
+
+The `LSP4TokenName` data key is OPTIONAL. If this data key is present and used, the following requirements apply:
+
+_Requirements_
+
+- the value of the `LSP4TokenName` MUST NOT be changeable and set only on deployment or during initialization of the token.
+
 
 ```json
   {
@@ -62,7 +69,21 @@ This MUST NOT be changeable, and set only during initialization of the token.
 
 #### LSP4TokenSymbol
 
-A string representing the symbol for the token collection. Symbols should be UPPERCASE, without spaces and contain only ASCII.
+A string representing the symbol for the token collection. 
+
+The `LSP4TokenSymbol` data key is OPTIONAL. If this data key is present and used, the following requirements and recommendations apply:
+
+_Requirements_
+
+- the value of the `LSP4TokenSymbol` MUST NOT be changeable and set only on deployment or during initialization of the token.
+
+
+_Recommendations_
+
+- Symbols SHOULD be **UPPERCASE**.
+- Symbols SHOULD NOT contain any white spaces.
+- Symbols SHOULD contain only ASCII characters.
+
 
 ```json
   {
@@ -73,8 +94,6 @@ A string representing the symbol for the token collection. Symbols should be UPP
       "valueContent": "String"
   }
 ```
-
-This MUST NOT be changeable, and set only during initialization of the token.
 
 
 #### LSP4Metadata
@@ -91,9 +110,11 @@ The description of the asset.
 }
 ```
 
-For more informations about how to construct the JSONURL, see: [ERC725Y JSON Schema > `valueContent` > `JSONURL`](./LSP-2-ERC725YJSONSchema.md#JSONURL)
+For more informations on how to construct the JSONURL, see: [ERC725Y JSON Schema > `valueContent` > `JSONURL`](./LSP-2-ERC725YJSONSchema.md#JSONURL)
 
 The linked JSON file SHOULD have the following format:
+
+> **Note:** the `"attributes"` field is OPTIONAL.
 
 ```js
 {
@@ -130,18 +151,21 @@ The linked JSON file SHOULD have the following format:
             ],
             [...]
         ],
-        "assets": [{
-            "hashFunction": 'keccak256(bytes)',
-            "hash": 'string',
-            "url": 'string',
-            "fileType": 'string'
-        }],
+        "assets": [
+            {
+                "hashFunction": 'keccak256(bytes)',
+                "hash": 'string',
+                "url": 'string',
+                "fileType": 'string'
+            }
+        ],
         "attributes": [
-        {
-            "key": "string",    // name of the attribute
-            "value": "string", // value assigned to the attribute
-            "type": "string | number | boolean",   // for encoding/decoding purposes
-        },
+            {
+                "key": "string",    // name of the attribute
+                "value": "string", // value assigned to the attribute
+                "type": "string | number | boolean",   // for encoding/decoding purposes
+            },
+        ]
         ...
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

- add the `"attributes"` array field in the JSON under the `LSP4Metadata`

- for the `LSP4TokenName` and `LSP4TokenSymbol`:
    - mark these data keys as optional
    - add sections for requirements + recommendations if these data key are used