### PR TITLE
[TRST-L1] mark ownership transfer/renounce functions as non-payable in LSP0

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -152,7 +152,7 @@ This function is part of the [LSP14] specification.
 #### transferOwnership
 
 ```solidity
-function transferOwnership(address newPendingOwner) external payable;
+function transferOwnership(address newPendingOwner) external;
 ```
 
 This function is part of the [LSP14] specification, with additional requirements as follows:
@@ -192,10 +192,10 @@ This function is part of the [LSP14] specification, with additional requirements
 #### renounceOwnership
 
 ```solidity
-function renounceOwnership() external payable;
+function renounceOwnership() external;
 ```
 
-This function is part of the [LSP14] specification with additional requirements:
+This function is part of the [LSP14] specification with additional requirements as follows:
 
 - MUST allow the owner to call the function. 
 


### PR DESCRIPTION
# What does this PR introduce?

Fix the specs for LSP0 for the function `transferOwnership(address)` and `renounceOwnership()`.
These functions are marked as `payable` but they shouldn't.