### PR TITLE
[WP-D8] add closing `}` at the end of the interface cheatsheet of LSP6

### DIFF
--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -836,7 +836,7 @@ interface ILSP6  /* is ERC165 */ {
 
     function executeRelayCall(bytes[] calldata signatures, uint256[] calldata nonces, uint256[] calldata values, bytes[] calldata payloads) external payable returns (bytes[] memory);
 
-
+}
 ```
 
 ## Copyright


### PR DESCRIPTION
# What does this PR introduce?

add missing closing curly bracket `}` in the interface cheatsheet of LSP6.