### PR TITLE
[TRST-R3] Specification improvements for LSP0 and LSP20

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -387,13 +387,17 @@ This function is part of the [LSP1] specification, with additional requirements 
 
 - MUST emit a [`ValueReceived`] event before external calls if the function receives native tokens.
 
+- MUST emit a [UniversalReceiver] event if the function was successful.
+
 - If an `address` is stored under the data key attached below and this address is a contract:
   - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
   - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
   
-- If there is no `address` stored under this data key, execution continues normally. 
+- If there is no `address` stored under this data key, execution continues normally.
 
-The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
+- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retrieved contract abi-encoded as `bytes`. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value MUST be two empty bytes abi-encoded as `bytes`. 
+
+The calldata (`msg.data`) is appended with the caller address as bytes20 and the amount of native tokens received (`msg.value`) as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
 ```json
 {
@@ -404,10 +408,6 @@ The `msg.data` is appended with the caller address as bytes20 and the `msg.value
   "valueContent": "Address"
 }
 ```
-
-- If an `address` is stored under the data key attached below and and this address is a contract that supports the [LSP1UniversalReceiver interface id], forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the address retreived. If there is no address stored under this data key, execution continues normally. 
-
-The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
 ```json
 {
@@ -420,10 +420,6 @@ The `msg.data` is appended with the caller address as bytes20 and the `msg.value
 ```
 
 > <bytes32\> is the `typeId` passed to the `universalReceiver(..)` function. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
-
-- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retreived contract abi-encoded as bytes. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value is the two empty bytes abi-encoded as bytes. 
-
-- MUST emit a [UniversalReceiver] event if the function was successful.
 
 ### Events
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -405,7 +405,11 @@ The `msg.data` is appended with the caller address as bytes20 and the `msg.value
 }
 ```
 
-- If an `address` is stored under the data key attached below and and this address is a contract that supports the [LSP1UniversalReceiver interface id], forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the address retreived. If there is no address stored under this data key, execution continues normally. 
+- If an `address` is stored under the data key attached below and this address is a contract:
+  - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
+  - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
+
+- If there is no `address` stored under this data key, execution continues normally. 
 
 The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
@@ -421,7 +425,7 @@ The `msg.data` is appended with the caller address as bytes20 and the `msg.value
 
 > <bytes32\> is the `typeId` passed to the `universalReceiver(..)` function. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
 
-- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retreived contract abi-encoded as bytes. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value is the two empty bytes abi-encoded as bytes. 
+- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retrieved contract abi-encoded as bytes. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value is the two empty bytes abi-encoded as bytes. 
 
 - MUST emit a [UniversalReceiver] event if the function was successful.
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -387,17 +387,13 @@ This function is part of the [LSP1] specification, with additional requirements 
 
 - MUST emit a [`ValueReceived`] event before external calls if the function receives native tokens.
 
-- MUST emit a [UniversalReceiver] event if the function was successful.
-
 - If an `address` is stored under the data key attached below and this address is a contract:
   - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
   - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
   
-- If there is no `address` stored under this data key, execution continues normally.
+- If there is no `address` stored under this data key, execution continues normally. 
 
-- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retrieved contract abi-encoded as `bytes`. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value MUST be two empty bytes abi-encoded as `bytes`. 
-
-The calldata (`msg.data`) is appended with the caller address as bytes20 and the amount of native tokens received (`msg.value`) as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
+The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
 ```json
 {
@@ -408,6 +404,10 @@ The calldata (`msg.data`) is appended with the caller address as bytes20 and the
   "valueContent": "Address"
 }
 ```
+
+- If an `address` is stored under the data key attached below and and this address is a contract that supports the [LSP1UniversalReceiver interface id], forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the address retreived. If there is no address stored under this data key, execution continues normally. 
+
+The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
 ```json
 {
@@ -420,6 +420,10 @@ The calldata (`msg.data`) is appended with the caller address as bytes20 and the
 ```
 
 > <bytes32\> is the `typeId` passed to the `universalReceiver(..)` function. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
+
+- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retreived contract abi-encoded as bytes. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value is the two empty bytes abi-encoded as bytes. 
+
+- MUST emit a [UniversalReceiver] event if the function was successful.
 
 ### Events
 

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -387,7 +387,11 @@ This function is part of the [LSP1] specification, with additional requirements 
 
 - MUST emit a [`ValueReceived`] event before external calls if the function receives native tokens.
 
-- If an `address` is stored under the data key attached below and and this address is a contract that supports the [LSP1UniversalReceiver interface id], forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the address retreived. If there is no address stored under this data key, execution continues normally. 
+- If an `address` is stored under the data key attached below and this address is a contract:
+  - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
+  - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
+  
+- If there is no `address` stored under this data key, execution continues normally. 
 
 The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 

--- a/LSPs/LSP-20-CallVerification.md
+++ b/LSPs/LSP-20-CallVerification.md
@@ -58,7 +58,8 @@ _Requirements_
 
 - the `bytes4` magic value returned MUST be of the following format: 
   - the first 3 bytes MUST be the `lsp20VerifyCall(..)` function selector = this determines if the call to the function is allowed.
-  - the last 4th byte MUST be either `0x00` or `0x01` = if the 4th byte is `0x01`, this determines if the `lsp20VerifyCallResult(..)` function should be called after the original function call (The byte that invokes the `lsp20VerifyCallResult(..)` function is strictly `0x01`).
+  - any value for the last 4th byte is accepted.
+  - if the 4th byte is `0x01`, this determines if the `lsp20VerifyCallResult(..)` function should be called after the original function call (The byte that invokes the `lsp20VerifyCallResult(..)` function is strictly `0x01`).
 
 
 #### lsp20VerifyCallResult

--- a/LSPs/LSP-20-CallVerification.md
+++ b/LSPs/LSP-20-CallVerification.md
@@ -40,9 +40,9 @@ Smart contracts implementing the LSP20 standard SHOULD implement both of the fun
 function lsp20VerifyCall(address caller, uint256 value, bytes memory receivedCalldata) external returns (bytes4 magicValue);
 ```
 
-MUST return the first 3 bytes of `lsp20VerifyCall(..)` function selector if the call to the function is allowed, concatenated with a byte that determines if the `lsp20VerifyCallResult(..)` function should be called after the original function call. 
+This function is the pre-verification function.
 
-The byte that invokes the `lsp20VerifyCallResult(..)` function is strictly `0x01`.
+It can be used to run any form of verification mechanism **prior to** running the actual function being called.
 
 _Parameters:_
 
@@ -50,8 +50,15 @@ _Parameters:_
 - `value`:  The value sent by the caller to the function called on the contract delegating the verification mechanism.
 - `receivedCalldata`: The calldata sent by the caller to the contract delegating the verification mechanism.
 
+_Returns:_ 
 
-_Returns:_ `magicValue` , the magic value determining if the verification succeeded or not.
+- `magicValue`: the magic value determining if the verification succeeded or not.
+
+_Requirements_
+
+- the `bytes4` magic value returned MUST be of the following format: 
+  - the first 3 bytes MUST be the `lsp20VerifyCall(..)` function selector = this determines if the call to the function is allowed.
+  - the last 4th byte MUST be either `0x00` or `0x01` = if the 4th byte is `0x01`, this determines if the `lsp20VerifyCallResult(..)` function should be called after the original function call (The byte that invokes the `lsp20VerifyCallResult(..)` function is strictly `0x01`).
 
 
 #### lsp20VerifyCallResult
@@ -60,16 +67,24 @@ _Returns:_ `magicValue` , the magic value determining if the verification succee
 function lsp20VerifyCallResult(bytes32 callHash, bytes memory callResult) external returns (bytes4 magicValue);
 ```
 
-MUST return the `lsp20VerifyCallResult(..)` function selector if the call to the function is allowed.
+This function is the **post-verification** function.
+
+It can be used to run any form of verification mechanism after having run the actual function that was initially called.
 
 _Parameters:_
 
 - `callHash`: The keccak256 of the parameters of `lsp20VerifyCall(..)` parameters packed-encoded (concatened).
-- `callResult`: The result of the function being called on the contract delegating the verification mechanism.
+- `callResult`: the result of the function being called on the contract delegating the verification mechanism.
+  - if the function being called returns some data, the `callResult` MUST be the value returned by the function being called as abi-encoded `bytes`.
+  - if the function being called does not return any data, the `callResult` MUST be an empty abi-encoded `bytes`.
 
-_Returns:_ `magicValue` , the magic value determining if the verification succeeded or not.
+_Returns:_ 
 
+- `magicValue`: the magic value determining if the verification succeeded or not.
 
+_Requirements_
+
+- MUST return the `lsp20VerifyCallResult(..)` function selector if the call to the function is allowed.
 ## Rationale
 
 TBD

--- a/LSPs/LSP-20-CallVerification.md
+++ b/LSPs/LSP-20-CallVerification.md
@@ -76,7 +76,7 @@ _Parameters:_
 - `callHash`: The keccak256 of the parameters of `lsp20VerifyCall(..)` parameters packed-encoded (concatened).
 - `callResult`: the result of the function being called on the contract delegating the verification mechanism.
   - if the function being called returns some data, the `callResult` MUST be the value returned by the function being called as abi-encoded `bytes`.
-  - if the function being called does not return any data, the `callResult` MUST be an empty abi-encoded `bytes`.
+  - if the function being called does not return any data, the `callResult` MUST be an empty `bytes`.
 
 _Returns:_ 
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -235,13 +235,17 @@ This function is part of the [LSP1] specification, with additional requirements 
 
 - MUST emit a [`ValueReceived`] event before external calls if the function receives native tokens.
 
+- MUST emit a [UniversalReceiver] event if the function was successful.
+
 - If an `address` is stored under the data key attached below and this address is a contract:
   - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
   - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
   
 - If there is no `address` stored under this data key, execution continues normally. 
 
-The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
+- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retrieved contract abi-encoded as `bytes`. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value is the two empty bytes abi-encoded as `bytes`. 
+
+The calldata (`msg.data`) is appended with the caller address as bytes20 and the amount of native tokens received (`msg.value`) received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
 ```json
 {
@@ -252,12 +256,6 @@ The `msg.data` is appended with the caller address as bytes20 and the `msg.value
   "valueContent": "Address"
 }
 ```
-
-- If an `address` is stored under the data key attached below and this address is a contract:
-  - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
-  - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
-  
-- If there is no `address` stored under this data key, execution continues normally. 
 
 The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
@@ -272,10 +270,6 @@ The `msg.data` is appended with the caller address as bytes20 and the `msg.value
 ```
 
 > <bytes32\> is the `typeId` passed to the `universalReceiver(..)` function. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
-
-- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retreived contract abi-encoded as bytes. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value is the two empty bytes abi-encoded as bytes. 
-
-- MUST emit a [UniversalReceiver] event if the function was successful.
 
 ### Events
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -235,7 +235,11 @@ This function is part of the [LSP1] specification, with additional requirements 
 
 - MUST emit a [`ValueReceived`] event before external calls if the function receives native tokens.
 
-- If an `address` is stored under the data key attached below and and this address is a contract that supports the [LSP1UniversalReceiver interface id], forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the address retreived. If there is no address stored under this data key, execution continues normally. 
+- If an `address` is stored under the data key attached below and this address is a contract:
+  - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
+  - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
+  
+- If there is no `address` stored under this data key, execution continues normally. 
 
 The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
@@ -249,7 +253,11 @@ The `msg.data` is appended with the caller address as bytes20 and the `msg.value
 }
 ```
 
-- If an `address` is stored under the data key attached below and and this address is a contract that supports the [LSP1UniversalReceiver interface id], forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the address retreived. If there is no address stored under this data key, execution continues normally. 
+- If an `address` is stored under the data key attached below and this address is a contract:
+  - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
+  - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
+  
+- If there is no `address` stored under this data key, execution continues normally. 
 
 The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -235,17 +235,13 @@ This function is part of the [LSP1] specification, with additional requirements 
 
 - MUST emit a [`ValueReceived`] event before external calls if the function receives native tokens.
 
-- MUST emit a [UniversalReceiver] event if the function was successful.
-
 - If an `address` is stored under the data key attached below and this address is a contract:
   - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
   - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
   
 - If there is no `address` stored under this data key, execution continues normally. 
 
-- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retrieved contract abi-encoded as `bytes`. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value is the two empty bytes abi-encoded as `bytes`. 
-
-The calldata (`msg.data`) is appended with the caller address as bytes20 and the amount of native tokens received (`msg.value`) received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
+The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
 ```json
 {
@@ -256,6 +252,12 @@ The calldata (`msg.data`) is appended with the caller address as bytes20 and the
   "valueContent": "Address"
 }
 ```
+
+- If an `address` is stored under the data key attached below and this address is a contract:
+  - forwards the call to the [`universalReceiver(bytes32,bytes)`] function on the contract at this address **ONLY IF** this contract supports the [LSP1UniversalReceiver interface id].
+  - if the contract at this address does not supports the [LSP1UniversalReceiver interface id], execution continues normally.
+  
+- If there is no `address` stored under this data key, execution continues normally. 
 
 The `msg.data` is appended with the caller address as bytes20 and the `msg.value` received as bytes32 before calling the external contract, allowing the receiving contract to know the initial caller and the value sent.
 
@@ -270,6 +272,10 @@ The `msg.data` is appended with the caller address as bytes20 and the `msg.value
 ```
 
 > <bytes32\> is the `typeId` passed to the `universalReceiver(..)` function. Check [LSP2-ERC725YJSONSchema] to learn how to encode the key.
+
+- MUST return the returned value of the `universalReceiver(bytes32,bytes)` function on both retreived contract abi-encoded as bytes. If there is no addresses stored under the data keys above or the call was not forwarded to them, the return value is the two empty bytes abi-encoded as bytes. 
+
+- MUST emit a [UniversalReceiver] event if the function was successful.
 
 ### Events
 


### PR DESCRIPTION
# What does this PR introduce?

## LSP0 + LSP9

- Improve the specs for LSP0 and LSP9 `universalReceiver(...)` function to describe that execution continues normally if the address stored under the data keys `LSP1UniversalReceiverDelegate` and `LSP1UniversalReceiverDelegate:<bytes32>` do not support the LSP1 interface ID.
- group the content for both LSP1 data keys in one big section paragraph.

## LSP20

- add _Requirements_ as subheaders for each methods.
- explicitly state that if the function being called does not return anything, the `callResult` value MUST be an empty `bytes`
Improve specs.
- add brief description under each method `lsp20VerifyCall(...)` and `lsp20VerifyCallResult(...)`