### PR TITLE
Remove function overloading for ERC725 and LSP6

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -56,7 +56,7 @@ This allows us to:
 
 ## Specification
 
-**LSP0-ERC725Account** interface id according to [ERC165]: `0x405befe2`.
+**LSP0-ERC725Account** interface id according to [ERC165]: `0x3e89ad98`.
 
 _This `bytes4` interface id is calculated as the XOR of the selector of [`batchCalls`](#batchcalls) function and the following standards: ERC725Y, ERC725X, LSP1-UniversalReceiver, ERC1271-isValidSignature, LSP14Ownable2Step, LSP17Extendable and LSP20CallVerification_.
 
@@ -265,10 +265,10 @@ This function is part of the [ERC725X] specification, with additional requiremen
 - MUST emit a [`ValueReceived`] event before external calls or contract creation if the function receives native tokens.
 
 
-#### execute (Array)
+#### executeBatch
 
 ```solidity
-function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns (bytes[] memory);
+function executeBatch(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns (bytes[] memory);
 ```
 This function is part of the [ERC725X] specification, with additional requirements as follows:
 
@@ -282,7 +282,7 @@ This function is part of the [ERC725X] specification, with additional requiremen
 
 - If the `lsp20VerifyCall(..)` function is called and returns bytes4 where the first bytes3 match the first bytes3 of the lsp20VerifyCall selector, and the last byte is strictly `0x01`, the function MUST call the [`lsp20VerifyCallResult(..)`](./LSP-20-CallVerification.md#lsp20verifycallresult) function on the [owner](#owner) as per the [LSP20-CallVerification] specification.
 
-  The function MUST be called **after the execution of the execute logic**, passing the hash of the caller, value sent, and data sent concatenated, and the result of the `execute(..)` function represented by the bytes encoding as bytes of the array of call results or the addresses of the contracts created as a second parameter.  
+  The function MUST be called **after the execution of the execute logic**, passing the hash of the caller, value sent, and data sent concatenated, and the result of the `executeBatch(..)` function represented by the bytes encoding as bytes of the array of call results or the addresses of the contracts created as a second parameter.  
 
   The call will pass if the bytes4 returned by the `lsp20VerifyCallResult(..)` function equals the `lsp20VerifyCallResult(..)` function selector, otherwise MUST revert.
 
@@ -298,10 +298,10 @@ function getData(bytes32 dataKey) external view returns (bytes memory);
 This function is part of the [ERC725Y] specification.
 
 
-#### getData
+#### getDataBatch
 
 ```solidity
-function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory);
+function getDataBatch(bytes32[] memory dataKeys) external view returns (bytes[] memory);
 ```
 
 This function is part of the [ERC725Y] specification.
@@ -325,7 +325,7 @@ This function is part of the [ERC725Y] specification, with additional requiremen
 
 - If the `lsp20VerifyCall(..)` function is called and returns bytes4 where the first bytes3 match the first bytes3 of the lsp20VerifyCall selector, and the last byte is strictly `0x01`, the function MUST call the [`lsp20VerifyCallResult(..)`](./LSP-20-CallVerification.md#lsp20verifycallresult) function on the [owner](#owner) as per the [LSP20-CallVerification] specification.
 
-  The function MUST be called **after the execution of the setData logic**, passing the hash of the caller, value sent, and data sent concatenated, and the result of the `execute(..)` function represented by empty bytes as a second parameter.  
+  The function MUST be called **after the execution of the setData logic**, passing the hash of the caller, value sent, and data sent concatenated, and the result of the `setData(..)` function represented by empty bytes as a second parameter.  
 
   The call will pass if the bytes4 returned by the `lsp20VerifyCallResult(..)` function equals the `lsp20VerifyCallResult(..)` function selector, otherwise MUST revert.
   
@@ -336,10 +336,10 @@ This function is part of the [ERC725Y] specification, with additional requiremen
 - MUST emit only the first 256 bytes of the dataValue parameter in the [DataChanged] event.
 
 
-#### setData (Array)
+#### setDataBatch
 
 ```solidity
-function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable;
+function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable;
 ```
 
 This function is part of the [ERC725Y] specification, with additional requirements as follows:
@@ -348,13 +348,13 @@ This function is part of the [ERC725Y] specification, with additional requiremen
 
 - If the caller is not the owner, the function MUST call the [`lsp20VerifyCall(..)`](./LSP-20-CallVerification.md#lsp20verifycall) function on the [owner](#owner) as per the [LSP20-CallVerification] specification.
 
-  The function MUST be called **before the execution of the setData logic**, passing the caller, value sent to the function, and the data sent (function selector + arguments + extra calldata) as parameters. 
+  The function MUST be called **before the execution of the setDataBatch logic**, passing the caller, value sent to the function, and the data sent (function selector + arguments + extra calldata) as parameters. 
 
   The function should only continue executing if the `lsp20VerifyCall(..)` function returns bytes4 where the first bytes3 match the first bytes3 of the `lsp20VerifyCall(..)` selector, otherwise MUST revert.
 
 - If the `lsp20VerifyCall(..)` function is called and returns bytes4 where the first bytes3 match the first bytes3 of the lsp20VerifyCall selector, and the last byte is strictly `0x01`, the function MUST call the [`lsp20VerifyCallResult(..)`](./LSP-20-CallVerification.md#lsp20verifycallresult) function on the [owner](#owner) as per the [LSP20-CallVerification] specification.
 
-  The function MUST be called **after the execution of the setData logic**, passing the hash of the caller, value sent, and data sent concatenated, and the result of the `execute(..)` function represented by empty bytes as a second parameter.  
+  The function MUST be called **after the execution of the setDataBatch logic**, passing the hash of the caller, value sent, and data sent concatenated, and the result of the `setDataBatch(..)` function represented by empty bytes as a second parameter.  
 
   The call will pass if the bytes4 returned by the `lsp20VerifyCallResult(..)` function equals the `lsp20VerifyCallResult(..)` function selector, otherwise MUST revert.
   
@@ -542,7 +542,7 @@ interface ILSP0  /* is ERC165 */ {
     
     function execute(uint256 operationType, address to, uint256 value, bytes memory data) external payable returns (bytes memory); 
     
-    function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory); 
+    function executeBatch(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory); 
     
     
     // ERC725Y
@@ -554,9 +554,9 @@ interface ILSP0  /* is ERC165 */ {
     
     function setData(bytes32 dataKey, bytes memory dataValue) external payable; 
 
-    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory dataValues);
+    function getDataBatch(bytes32[] memory dataKeys) external view returns (bytes[] memory dataValues);
 
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable; 
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable; 
 
         
     // ERC1271

--- a/LSPs/LSP-6-KeyManager.md
+++ b/LSPs/LSP-6-KeyManager.md
@@ -37,7 +37,7 @@ Storing the permissions at the core [ERC725Account] itself, allows it to survive
 
 ## Specification
 
-**LSP6-KeyManager** interface id according to [ERC165]: `0xfb437414`.
+**LSP6-KeyManager** interface id according to [ERC165]: `0x06561226`.
 
 Smart contracts implementing the LSP6 standard MUST implement the [ERC165] `supportsInterface(..)` function and MUST support the [ERC165], [ERC1271], [LSP20-CallVerification] and the LSP6 interface ids.
 
@@ -81,7 +81,7 @@ This function is part of the [LSP20-CallVerification] specification, with additi
 
 - MUST emit the [VerifiedCall](#verifiedcall) event after verifying permissions. 
 
-- MUST set the reentrancy guard to true if the first 4 bytes of `receivedCalldata` are any function other than `setData(..)` and check for reentrancy permission if the call was reentrant.
+- MUST set the reentrancy guard to true if the first 4 bytes of `receivedCalldata` are any function other than `setData(..)`/`setDataBatch(..)` and check for reentrancy permission if the call was reentrant.
 
 - MUST return the magic value with the `0x01` bytes that indicates that `lsp20VerifyCallResult(..)` MUST be invoked.
 
@@ -146,7 +146,7 @@ _Requirements:_
 - The first 4 bytes of the `payload` payload MUST correspond to one of the function selector on the ERC725 smart contract such as:
 
     - [`setData(bytes32,bytes)`](./LSP-0-ERC725Account.md#setdata)
-    - [`setData(bytes32[],bytes[])`](./LSP-0-ERC725Account.md#setdata-array)
+    - [`setDataBatch(bytes32[],bytes[])`](./LSP-0-ERC725Account.md#setdatabatch)
     - [`execute(uint256,address,uint256,bytes)`](./LSP-0-ERC725Account.md#execute)
     - [`transferOwnership(address)`](./LSP-0-ERC725Account.md#transferownership)
     - [`acceptOwnership()`](./LSP-0-ERC725Account.md#acceptownership)
@@ -158,10 +158,10 @@ _Requirements:_
 - The caller MUST have **permission** for the action being executed. Check [Permissions](#permissions) to know more.
 
 
-#### execute (Array)
+#### executeBatch
 
 ```solidity
-function execute(uint256[] memory values, bytes memory payloads[]) external payable returns (bytes[] memory)
+function executeBatch(uint256[] memory values, bytes memory payloads[]) external payable returns (bytes[] memory)
 ```
 
 Execute a batch of payloads on the linked [target](#target) contract.
@@ -231,10 +231,10 @@ For signing, permissioned users should apply the same steps and sign the final h
 > Non payable functions will revert in case of calling them and passing value along the call.
 
 
-#### executeRelayCall (Array)
+#### executeRelayCallBatch
 
 ```solidity
-function executeRelayCall(bytes[] memory signatures, uint256[] memory nonces, uint256[] memory values, bytes[] memory payloads) external payable returns (bytes[] memory)
+function executeRelayCallBatch(bytes[] memory signatures, uint256[] memory nonces, uint256[] memory values, bytes[] memory payloads) external payable returns (bytes[] memory)
 ```
 
 
@@ -277,9 +277,9 @@ the function/method being called:
 
 - against the **caller** parameter in the cases of [`lsp20VerifyCall(address,uint256,bytes)`](#lsp20verifycall).
 
-- against the **caller** in the cases of [`execute(bytes)`](#execute) and [`execute(uint256[],bytes[])`](#execute-array).
+- against the **caller** in the cases of [`execute(bytes)`](#execute) and [`executeBatch(uint256[],bytes[])`](#executebatch).
 
-- against the **signer address**, recovered from the signature and the digest, in the cases of [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall) and [`executeRelayCall(bytes[],uint256[],uint256[],bytes[])`](#executerelaycall-array).
+- against the **signer address**, recovered from the signature and the digest, in the cases of [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall) and [`executeRelayCallBatch(bytes[],uint256[],uint256[],bytes[])`](#executerelaycallbatch).
 
 The permissions MUST be stored as [BitArray] under the [`AddressPermissions:Permissions:<address>`](#addresspermissionspermissionsaddress) data key on the target.
 
@@ -349,7 +349,7 @@ BitArray representation: `0x0000000000000000000000000000000000000000000000000000
 
 BitArray representation: `0x0000000000000000000000000000000000000000000000000000000000000080`
 
-- Allows reentering the public [`execute(bytes)`](#execute), [`execute(uint256[],bytes[])`](#execute-array), [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall) and [`executeRelayCall(bytes[],uint256[],uint256[],bytes[])`](#executerelaycall-array) functions.
+- Allows reentering the public [`execute(bytes)`](#execute), [`executeBatch(uint256[],bytes[])`](#executebatch), [`executeRelayCall(bytes,uint256,bytes)`](#executerelaycall) and [`executeRelayCallBatch(bytes[],uint256[],uint256[],bytes[])`](#executerelaycallbatch) functions.
 
 
 #### `SUPER_TRANSFERVALUE`
@@ -829,12 +829,12 @@ interface ILSP6  /* is ERC165 */ {
 
     function execute(bytes calldata payload) external payable returns (bytes memory);
 
-    function execute(uint256[] calldata values, bytes[] calldata payloads) external payable returns (bytes[] memory);
+    function executeBatch(uint256[] calldata values, bytes[] calldata payloads) external payable returns (bytes[] memory);
 
 
     function executeRelayCall(bytes calldata signature, uint256 nonce, bytes calldata payload) external payable returns (bytes memory);
 
-    function executeRelayCall(bytes[] calldata signatures, uint256[] calldata nonces, uint256[] calldata values, bytes[] calldata payloads) external payable returns (bytes[] memory);
+    function executeRelayCallBatch(bytes[] calldata signatures, uint256[] calldata nonces, uint256[] calldata values, bytes[] calldata payloads) external payable returns (bytes[] memory);
 
 }
 ```

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -276,9 +276,9 @@ interface ILSP7 is /* IERC165 */ {
     
     function setData(bytes32 dataKey, bytes memory value) external; // onlyOwner
 
-    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory values);
+    function getDataBatch(bytes32[] memory dataKeys) external view returns (bytes[] memory values);
 
-    function setData(bytes32[] memory dataKeys, bytes[] memory values) external; // onlyOwner
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory values) external; // onlyOwner
 
 
     // LSP7

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -507,9 +507,9 @@ interface ILSP8 is /* IERC165 */ {
     
     function setData(bytes32 dataKey, bytes memory value) external; // onlyOwner
 
-    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory values);
+    function getDataBatch(bytes32[] memory dataKeys) external view returns (bytes[] memory values);
 
-    function setData(bytes32[] memory dataKeys, bytes[] memory values) external; // onlyOwner
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory values) external; // onlyOwner
 
 
     // LSP8

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -24,7 +24,7 @@ This standard defines a vault that can hold assets and interact with other contr
 
 ## Specification
 
-**LSP9-Vault** interface id according to [ERC165]: `0x19331ad1`.
+**LSP9-Vault** interface id according to [ERC165]: `0x28af17e6`.
 
 _This `bytes4` interface id is calculated as the XOR of the selector of batchCalls function and the following standards: ERC725Y, ERC725X, LSP1-UniversalReceiver, LSP14Ownable2Step and LSP17Extendable._
 
@@ -166,10 +166,10 @@ This function is part of the [ERC725X] specification, with additional requiremen
 - MUST emit a [`ValueReceived`] event before external calls or contract creation if the function receives native tokens.
 
 
-#### execute (Array)
+#### executeBatch
 
 ```solidity
-function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns (bytes[] memory);
+function executeBatch(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns (bytes[] memory);
 ```
 This function is part of the [ERC725X] specification, with additional requirements as follows:
 
@@ -187,10 +187,10 @@ function getData(bytes32 dataKey) external view returns (bytes memory);
 This function is part of the [ERC725Y] specification.
 
 
-#### getData
+#### getDataBatch
 
 ```solidity
-function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory);
+function getDataBatch(bytes32[] memory dataKeys) external view returns (bytes[] memory);
 ```
 
 This function is part of the [ERC725Y] specification.
@@ -210,10 +210,10 @@ This function is part of the [ERC725Y] specification, with additional requiremen
 - MUST emit only the first 256 bytes of the dataValue parameter in the [DataChanged] event.
 
 
-#### setData (Array)
+#### setDataBatch
 
 ```solidity
-function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
+function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
 ```
 
 This function is part of the [ERC725Y] specification, with additional requirements as follows:
@@ -422,7 +422,7 @@ interface ILSP9  /* is ERC165 */ {
     
     function execute(uint256 operationType, address to, uint256 value, bytes memory data) external payable returns (bytes memory); // onlyOwner
     
-    function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory); // onlyOwner
+    function executeBatch(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory); // onlyOwner
     
     
     // ERC725Y
@@ -434,9 +434,9 @@ interface ILSP9  /* is ERC165 */ {
     
     function setData(bytes32 dataKey, bytes memory dataValue) external; // onlyOwner
     
-    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory dataValues);
+    function getDataBatch(bytes32[] memory dataKeys) external view returns (bytes[] memory dataValues);
     
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external; // onlyOwner
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues) external; // onlyOwner
     
     
     // LSP9 (LSP9Vault)


### PR DESCRIPTION
## What does this PR introduce ?

- Remove the function overloading
- Update `setData` to `setDataBatch` , `getData` to `getDataBatch` , `execute` to `executeBatch`, `executeRelayCall` to `executeRelayCallBatch`
- Update interfaceIds