### PR TITLE
Update LSP15 to include validityTimestamps

### DIFF
--- a/LSPs/LSP-15-TransactionRelayServiceAPI.md
+++ b/LSPs/LSP-15-TransactionRelayServiceAPI.md
@@ -14,21 +14,28 @@ A Transaction Relay Service API for consistency across all Transaction Relay Ser
 
 ## Abstract
 
-The [LSP-6-KeyManager](./LSP-6-KeyManager.md) proposes an [`executeRelayCall()`](./LSP-6-KeyManager.md#executerelaycall) function. It allows anybody to execute `_calldata` payload on a set ERC725 X or Y smart contract, given they have a signed message from a valid executor. This opens the way to Transaction Relay Services which send transactions on behalf of a user to cover their gas costs. 
+The [LSP-6-KeyManager](./LSP-6-KeyManager.md) proposes an [`executeRelayCall()`](./LSP-6-KeyManager.md#executerelaycall) function. It allows anybody to execute `_calldata` payload on a set ERC725 X or Y smart contract, given they have a signed message from a valid executor. This opens the way to Transaction Relay Services which send transactions on behalf of a user to cover their gas costs.
 
 This document describes the API for a Transaction Relay Service.
 
 ## Motivation
+
 Standardizing the Transaction Relay Service API enables applications to be compatible with all Transaction Relay Services which may be built, and avoids a situation where specific applications are only compatible with specific Transaction Relay Services. This is essential for an open marketplace of Transaction Relay Services where a user can select the service which best fits their needs.
 
 ## Specification
 
 ### API
 
-
 #### POST `/execute`
 
-Executes a signed transaction on behalf of a Universal Profile using `executeRelayCall()`.
+Executes a signed transaction on behalf of a Universal Profile using `executeRelayCall`.
+
+- `address` - The address of the Universal Profile which is executing the transaction.
+- `transaction` - An object containing the transaction parameters which will be executed with `executeRelayCall`.
+  - `abi` - The abi-encoded transaction data (_e.g: a function call on the Universal Profile smart contract_) which will be passed as the payload parameter to the `executeRelayCall` function.
+  - `signature` - The signed message according to LSP6 specification.
+  - `nonce` - The nonce of the KeyManager fetched by calling `getNonce(address address, uint128 channelId)` on the LSP6 KeyManager contract.
+  - `validityTimestamps` (optional) - Two concatenated `uint128` timestamps which indicate a time duration for which the transaction will be considered valid. If no validityTimestamps parameter is passed the relayer should assume that validityTimestamps is `0` and the transaction will be valid indefinitely until it is executed.
 
 ##### Request body
 
@@ -38,8 +45,9 @@ Executes a signed transaction on behalf of a Universal Profile using `executeRel
   "transaction": {
     "abi": "0x7f23690c5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000596f357c6aa5a21984a83b7eef4cb0720ac1fcf5a45e9d84c653d97b71bbe89b7a728c386a697066733a2f2f516d624b43744b4d7573376741524470617744687a32506a4e36616f64346b69794e436851726d3451437858454b00000000000000",
     "signature": "0x43c958b1729586749169599d7e776f18afc6223c7da21107161477d291d497973b4fc50a724b1b2ab98f3f8cf1d5cdbbbdf3512e4fbfbdc39732229a15beb14a1b",
-    "nonce": 1 // KeyManager nonce
-  },
+    "nonce": 1, // KeyManager nonce
+    "validityTimestamps": "0x0000000000000000000000006420f3f000000000000000000000000065ec82d0"
+  }
 }
 ```
 
@@ -47,7 +55,7 @@ Executes a signed transaction on behalf of a Universal Profile using `executeRel
 
 ```json
 {
-  "transactionHash": "0xBB645D97B0c7D101ca0d73131e521fe89B463BFD",
+  "transactionHash": "0xBB645D97B0c7D101ca0d73131e521fe89B463BFD"
 }
 ```
 
@@ -55,9 +63,9 @@ Executes a signed transaction on behalf of a Universal Profile using `executeRel
 
 Returns the available quota left for a registered Universal Profile.
 
-- `signature` is the result of signing a hash calculated as an EIP-712 hash where the message is keccak256(`address`, `timestamp`). 
-- `address` is the controller address with permissions on the Universal Profile used to create the signature value. 
-- `timestamp` represents the time the signature was created. Must be +/- 300 seconds from current time to be considered a valid request. Value should be `int`, `int256`, `uint` or `uint256`.
+- `signature` - The result of signing a hash calculated as an EIP-712 hash where the message is keccak256(`address`, `timestamp`).
+- `address` - The controller address with permissions on the Universal Profile used to create the signature value.
+- `timestamp` - Represents the time the signature was created. Must be +/- 300 seconds from current time to be considered a valid request. Value should be `int`, `int256`, `uint` or `uint256`.
 
 ##### Request body
 
@@ -86,7 +94,6 @@ Returns the available quota left for a registered Universal Profile.
 - `resetDate` gives date that available quota will reset, e.g. a monthly allowance
 
 > Quota systems could also use a Pay As You Go model, in which case totalQuota and resetData can be omitted
-
 
 ## Copyright
 


### PR DESCRIPTION
Add validityTimestamps to Relayer API spec. 
If no validity timestamps value is passed the relayer should assume it is 0