### PR TITLE
Update old schemas at the bottom of LSP8 specs

### DIFF
--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -1,14 +1,14 @@
 ---
 lip: 4
 title: Digital Asset Metadata
-author: Fabian Vogelsteller <fabian@lukso.network> 
+author: Fabian Vogelsteller <fabian@lukso.network>
 discussions-to: https://discord.gg/E2rJPP4
 status: Draft
 type: LSP
 created: 2020-07-21
 requires: ERC725Y, LSP2
 ---
- 
+
 ## Simple Summary
 
 This standard describes a set of [ERC725Y](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md) data key-value pairs that describe a digital asset.
@@ -24,7 +24,6 @@ As NFTs mostly have a creator, those creators should be able to improve the asse
 One could even think of a smart contract system that can increase attributes based on certain inputs automatically.
 
 An LSP4 Digital Asset is controlled by a single `owner`, expected to be a [ERC725](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md) smart contract. This owner is able to [`setData(...)`](https://github.com/ERC725Alliance/ERC725/blob/main/docs/ERC-725.md#setdata), and therefore change values of data keys, and can potentially mint new items.
- 
 
 ## Specification
 
@@ -36,11 +35,11 @@ The supported standard SHOULD be `LSP4DigitalAsset`
 
 ```json
 {
-    "name": "SupportedStandards:LSP4DigitalAsset",
-    "key": "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
-    "keyType": "Mapping",
-    "valueType": "bytes4",
-    "valueContent": "0xa4d96624"
+  "name": "SupportedStandards:LSP4DigitalAsset",
+  "key": "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
+  "keyType": "Mapping",
+  "valueType": "bytes4",
+  "valueContent": "0xa4d96624"
 }
 ```
 
@@ -54,22 +53,21 @@ _Requirements_
 
 - the value of the `LSP4TokenName` MUST NOT be changeable and set only on deployment or during initialization of the token.
 
-
 ```json
-  {
-      "name": "LSP4TokenName",
-      "key": "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
-      "keyType": "Singleton",
-      "valueType": "string",
-      "valueContent": "String"
-  }
+{
+  "name": "LSP4TokenName",
+  "key": "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
+  "keyType": "Singleton",
+  "valueType": "string",
+  "valueContent": "String"
+}
 ```
 
 This MUST NOT be changeable, and set only during initialization of the token.
 
 #### LSP4TokenSymbol
 
-A string representing the symbol for the token collection. 
+A string representing the symbol for the token collection.
 
 The `LSP4TokenSymbol` data key is OPTIONAL. If this data key is present and used, the following requirements and recommendations apply:
 
@@ -77,24 +75,21 @@ _Requirements_
 
 - the value of the `LSP4TokenSymbol` MUST NOT be changeable and set only on deployment or during initialization of the token.
 
-
 _Recommendations_
 
 - Symbols SHOULD be **UPPERCASE**.
 - Symbols SHOULD NOT contain any white spaces.
 - Symbols SHOULD contain only ASCII characters.
 
-
 ```json
-  {
-      "name": "LSP4TokenSymbol",
-      "key": "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
-      "keyType": "Singleton",
-      "valueType": "string",
-      "valueContent": "String"
-  }
+{
+  "name": "LSP4TokenSymbol",
+  "key": "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
+  "keyType": "Singleton",
+  "valueType": "string",
+  "valueContent": "String"
+}
 ```
-
 
 #### LSP4Metadata
 
@@ -102,11 +97,11 @@ The description of the asset.
 
 ```json
 {
-    "name": "LSP4Metadata",
-    "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
-    "keyType": "Singleton",
-    "valueType": "bytes",
-    "valueContent": "JSONURL"
+  "name": "LSP4Metadata",
+  "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
+  "keyType": "Singleton",
+  "valueType": "bytes",
+  "valueContent": "JSONURL"
 }
 ```
 
@@ -198,7 +193,7 @@ Example:
                     hashFunction: 'keccak256(bytes)',
                     hash: '0xa9399df007997de92a820c6c2ec1cb2d3f5aa5fc1adf294157de563eba39bb6e',
                     url: 'ifps://QmW4wM4r9yWeY1gUCtt7c6v3ve7Fzdg8CKvTS96NU9Uiwr'
-                }, 
+                },
                 ... // more image sizes
             ],
             ... // more images
@@ -236,11 +231,11 @@ An array of ([ERC725Account](./LSP-0-ERC725Account.md)) addresses that defines t
 
 ```json
 {
-    "name": "LSP4Creators[]",
-    "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
-    "keyType": "Array",
-    "valueType": "address",
-    "valueContent": "Address"
+  "name": "LSP4Creators[]",
+  "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
+  "keyType": "Array",
+  "valueType": "address",
+  "valueContent": "Address"
 }
 ```
 
@@ -250,20 +245,21 @@ For more informations about how to access each index of the `LSP4Creators[]` arr
 
 References the creator addresses for this asset. This data key exists so that smart contracts can detect whether the address of a creator is present in the `LSP4Creators[]` array without looping all over it on-chain. Moreover, it helps to identify at which index in the `LSP4Creators[]` the creator address is located for easy access and to change or remove this specific creator from the array. Finally, it also allows the detection of the interface supported by the creator.
 
-The `valueContent` MUST be constructed as follows: `bytes4(standardInterfaceId) + uint128(indexNumber)`. 
+The `valueContent` MUST be constructed as follows: `bytes4(standardInterfaceId) + uint128(indexNumber)`.
 Where:
+
 - `standardInterfaceId` = if the creator address is a smart contract, the [ERC165 interface ID](https://eips.ethereum.org/EIPS/eip-165) of the standard that the smart contract implements. Otherwise `0xffffffff` in the case where the creator address is:
-  - an Externally Owned Account, or 
+  - an Externally Owned Account, or
   - a contract implementing no ERC165 interface ID.
 - `indexNumber` = the index in the [`LSP4Creators[]` Array](##lsp4creators)
 
 ```json
 {
-    "name": "LSP4CreatorsMap:<address>",
-    "key": "0x6de85eaf5d982b4e5da00000<address>",
-    "keyType": "Mapping",
-    "valueType": "(bytes4,uint128)",
-    "valueContent": "(Bytes4,Number)"
+  "name": "LSP4CreatorsMap:<address>",
+  "key": "0x6de85eaf5d982b4e5da00000<address>",
+  "keyType": "Mapping",
+  "valueType": "(bytes4,uint128)",
+  "valueContent": "(Bytes4,Number)"
 }
 ```
 
@@ -274,54 +270,54 @@ There can be many token implementations, and this standard fills a need for comm
 ## Implementation
 
 An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/blob/main/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol) repository.
-The below defines the JSON interface of the `LSP4DigitalAsset`.
+The below defines the JSON interface of the `LSP4DigitalAssetMetadata`.
 
-ERC725Y JSON Schema `LSP4DigitalAsset`:
+ERC725Y JSON Schema `LSP4DigitalAssetMetadata`:
 
 ```json
 [
-    {
-        "name": "SupportedStandards:LSP4DigitalAsset",
-        "key": "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
-        "keyType": "Mapping",
-        "valueType": "bytes4",
-        "valueContent": "0xa4d96624"
-    },
-    {
-        "name": "LSP4TokenName",
-        "key": "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
-        "keyType": "Singleton",
-        "valueType": "string",
-        "valueContent": "String"
-    },
-    {
-        "name": "LSP4TokenSymbol",
-        "key": "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
-        "keyType": "Singleton",
-        "valueType": "string",
-        "valueContent": "String"
-    },
-    {
-        "name": "LSP4Metadata",
-        "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
-        "keyType": "Singleton",
-        "valueType": "bytes",
-        "valueContent": "JSONURL"
-    },
-    {
-        "name": "LSP4Creators[]",
-        "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
-        "keyType": "Array",
-        "valueType": "address",
-        "valueContent": "Address"
-    },
-    {
-        "name": "LSP4CreatorsMap:<address>",
-        "key": "0x6de85eaf5d982b4e5da00000<address>",
-        "keyType": "Mapping",
-        "valueType": "(bytes4,uint128)",
-        "valueContent": "(Bytes4,Number)"
-    }
+  {
+    "name": "SupportedStandards:LSP4DigitalAsset",
+    "key": "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
+    "keyType": "Mapping",
+    "valueType": "bytes4",
+    "valueContent": "0xa4d96624"
+  },
+  {
+    "name": "LSP4TokenName",
+    "key": "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
+    "keyType": "Singleton",
+    "valueType": "string",
+    "valueContent": "String"
+  },
+  {
+    "name": "LSP4TokenSymbol",
+    "key": "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
+    "keyType": "Singleton",
+    "valueType": "string",
+    "valueContent": "String"
+  },
+  {
+    "name": "LSP4Metadata",
+    "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
+    "keyType": "Singleton",
+    "valueType": "bytes",
+    "valueContent": "JSONURL"
+  },
+  {
+    "name": "LSP4Creators[]",
+    "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
+    "keyType": "Array",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
+  {
+    "name": "LSP4CreatorsMap:<address>",
+    "key": "0x6de85eaf5d982b4e5da00000<address>",
+    "keyType": "Mapping",
+    "valueType": "(bytes4,uint128)",
+    "valueContent": "(Bytes4,Number)"
+  }
 ]
 ```
 

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -477,18 +477,25 @@ ERC725Y JSON Schema `LSP8IdentifiableDigitalAsset`:
     "valueContent": "Number"
   },
   {
-    "name": "LSP8MetadataAddress:<address|uint256|bytes32>",
-    "key": "0x73dcc7c3c4096cdc7f8a0000<address|uint256|bytes32>",
+    "name": "LSP8MetadataTokenURI:<address|uint256|bytes32|string>",
+    "key": "0x4690256ef7e93288012f0000<address|uint256|bytes32|string>",
     "keyType": "Mapping",
-    "valueType": "Mixed",
-    "valueContent": "Mixed"
+    "valueType": "(bytes4,string)",
+    "valueContent": "(Bytes4,URI)"
   },
   {
-    "name": "LSP8MetadataJSON:<address|uint256|bytes32>",
-    "key": "0x9a26b4060ae7f7d5e3cd0000<address|uint256|bytes32>",
-    "keyType": "Mapping",
-    "valueType": "bytes",
-    "valueContent": "JSONURL"
+    "name": "LSP8TokenMetadataBaseURI",
+    "key": "0x1a7628600c3bac7101f53697f48df381ddc36b9015e7d7c9c5633d1252aa2843",
+    "keyType": "Singleton",
+    "valueType": "(bytes4,string)",
+    "valueContent": "(Bytes4,URI)"
+  },
+  {
+    "name": "LSP8ReferenceContract",
+    "key": "0x708e7b881795f2e6b6c2752108c177ec89248458de3bf69d0d43480b3e5034e6",
+    "keyType": "Singleton",
+    "valueType": "(address,bytes32)",
+    "valueContent": "(Address,bytes32)"
   }
 ]
 ```


### PR DESCRIPTION
# What does this PR introduce?

-  fix typo in LSP4 specs (the LSP4 MD file got prettified automatically)

- update old ERC725Y schema for LSP8 at the bottom of the specs