### PR TITLE
LSP3/4: change hash to verification data

### DIFF
--- a/LSPs/LSP-3-Profile-Metadata.md
+++ b/LSPs/LSP-3-Profile-Metadata.md
@@ -76,49 +76,66 @@ The linked JSON file SHOULD have the following format:
         ],
         "tags": [ "string", "string", ... ], // tags related to the profile
         "avatar": [ // a 3D file avatar mostly in FBX and/or OBJ format, multiple file formats of an avatar can be added
-            {
-                "hashFunction": 'keccak256(bytes)',
-                "hash": 'string',
+            { // example of a hash based avatar verification
+                "verificationFunction": 'keccak256(bytes)',
+                "verificationData": 'string',
                 "url": 'string',
                 "fileType": 'string'
             },
-            ...
-            // OR link a DigitalAsset (NFT)
-            {  
+            { // example of a signature based avatar verification
+                "verificationFunction": 'ecdsa',
+                "verificationData": 'string',  // signer that signed the bytes of the image
+                "verificationSource": 'string' // e.g url returning the signature of the signed image
+                "url": 'string',
+                "fileType": 'string'
+            },
+            { // example of a NFT/smart contract based avatar
                 "address": Address, // the address of an LSP7 or LSP8
                 "tokenId": 32bytes  // (optional) if token contract is an LSP7
             }
         ]
         // below each image type SHOULD have different size of the same image, so that interfaces can choose which one to load for better loading performance
         "profileImage": [ // One image in different sizes, representing the profile.
-            {  
+            { // example of a hash based image verification
                 "width": Number,
                 "height": Number,
-                "hashFunction": 'keccak256(bytes)',
-                "hash": 'string', // bytes32 hex string of the image hash
+                "verificationFunction": 'keccak256(bytes)',
+                "verificationData": 'string', // bytes32 hex string of the image hash
                 "url": 'string'
             },
-            ...
-            // OR link a DigitalAsset (NFT)
-            {  
+            { // example of a signature based image verification
+                "width": Number,
+                "height": Number,
+                "verificationFunction": 'ecdsa',
+                "verificationData": 'string',  // signer that signed the bytes of the image
+                "verificationSource": 'string' // e.g url returning the signature of the signed image
+                "url": 'string'
+            },
+            { // example of a NFT/smart contract based image
                 "address": Address, // the address of an LSP7 or LSP8
                 "tokenId": 32bytes  // (optional) if token contract is an LSP7
-            },
+            }
         ],
         "backgroundImage": [ // Image in different sizes, that can be used in conjunction with profile image to give a more personal look to a profile.
-            { 
+            { // example of a hash based image verification
                 "width": Number,
                 "height": Number,
-                "hashFunction": 'keccak256(bytes)',
-                "hash": 'string', // bytes32 hex string of the image hash
+                "verificationFunction": 'keccak256(bytes)',
+                "verificationData": 'string', // bytes32 hex string of the image hash
                 "url": 'string'
             },
-            ...
-             // OR link a DigitalAsset (NFT)
-            {  
+            { // example of a signature based image verification
+                "width": Number,
+                "height": Number,
+                "verificationFunction": 'ecdsa',
+                "verificationData": 'string',  // signer that signed the bytes of the image
+                "verificationSource": 'string' // e.g url returning the signature of the signed image
+                "url": 'string'
+            },
+            { // example of a NFT/smart contract based image
                 "address": Address, // the address of an LSP7 or LSP8
                 "tokenId": 32bytes  // (optional) if token contract is an LSP7
-            },
+            }
         ]
     }
 }
@@ -138,8 +155,8 @@ Example:
         tags: [ 'brand', 'public profile' ],
         avatar: [
             {
-              hashFunction: 'keccak256(bytes)',
-              hash: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
+              verificationFunction: 'keccak256(bytes)',
+              verificationData: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
               url: 'ifps://QmPJESHbVkPtSaHntNVY5F6JDLW8v69M2d6khXEYGUMn7N',
               fileType: 'fbx'
             }
@@ -148,8 +165,8 @@ Example:
             {
                 width: 1800,
                 height: 1013,
-                hashFunction: 'keccak256(bytes)',
-                hash: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
+                verificationFunction: 'keccak256(bytes)',
+                verificationData: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
                 url: 'ifps://QmPJESHbVkPtSaHntNVY5F6JDLW8v69M2d6khXEYGUMn7N'
             },
             // OR use an NFT as profile image
@@ -162,15 +179,15 @@ Example:
             {
                 width: 1800,
                 height: 1013,
-                hashFunction: 'keccak256(bytes)',
-                hash: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
+                verificationFunction: 'keccak256(bytes)',
+                verificationData: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
                 url: 'ifps://QmPJESHbVkPtSaHntNVY5F6JDLW8v69M2d6khXEYGUMn7N'
             },
             {
                 width: 1024,
                 height: 576,
-                hashFunction: 'keccak256(bytes)',
-                hash: '0xfce1c7436a77a009a97e48e4e10c92e89fd95fe1556fc5c62ecef57cea51aa37',
+                verificationFunction: 'keccak256(bytes)',
+                verificationData: '0xfce1c7436a77a009a97e48e4e10c92e89fd95fe1556fc5c62ecef57cea51aa37',
                 url: 'ifps://QmZc9uMJxyUeUpuowJ7AD6MKoNTaWdVNcBj72iisRyM9Su'
             }
         ]

--- a/LSPs/LSP-3-Profile-Metadata.md
+++ b/LSPs/LSP-3-Profile-Metadata.md
@@ -100,7 +100,7 @@ The linked JSON file SHOULD have the following format:
                 "width": Number,
                 "height": Number,
                 "verificationFunction": 'keccak256(bytes)',
-                "verificationData": 'string', // bytes32 hex string of the image hash
+                "verificationData": 'string', // bytes32 hash of the image
                 "url": 'string'
             },
             { // example of a signature based image verification
@@ -121,7 +121,7 @@ The linked JSON file SHOULD have the following format:
                 "width": Number,
                 "height": Number,
                 "verificationFunction": 'keccak256(bytes)',
-                "verificationData": 'string', // bytes32 hex string of the image hash
+                "verificationData": 'string', // bytes32 hash of the image
                 "url": 'string'
             },
             { // example of a signature based image verification

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -125,36 +125,64 @@ The linked JSON file SHOULD have the following format:
         ],
         "icon": [ // SHOULD be used for LSP7 icons
             // multiple sizes of the same icon
-            {
+            { // example of a verificationData based image verification
                 "width": Number,
                 "height": Number,
-                "hashFunction": 'keccak256(bytes)',
-                "hash": 'string', // bytes32 hex string of the image hash
+                "verificationFunction": 'keccak256(bytes)',
+                "verificationData": 'string', // bytes32 hex string of the image verificationData
                 "url": 'string'
             },
+            { // example of a signature based image verification
+                "width": Number,
+                "height": Number,
+                "verificationFunction": 'ecdsa',
+                "verificationData": 'string', // signer that signed the bytes of the image
+                "verificationSource": 'string' // e.g url returning the signature of the signed image
+                "url": 'string'
+            },
+            { // example of a NFT/smart contract based image
+                "address": Address, // the address of an LSP7 or LSP8
+                "tokenId": 32bytes  // (optional) if token contract is an LSP7
+            }
             ...
         ],
         "images": [ // COULD be used for LSP8 NFT art
             // multiple images in different sizes, related to the DigitalAsset, image 0, should be the main image
             // array of different sizes of the same image
             [
-                {
+                { // example of a verificationData based image verification
                     "width": Number,
                     "height": Number,
-                    "hashFunction": 'keccak256(bytes)',
-                    "hash": 'string', // bytes32 hex string of the image hash
+                    "verificationFunction": 'keccak256(bytes)',
+                    "verificationData": 'string', // bytes32 hex string of the image verificationData
                     "url": 'string'
                 },
+                { // example of a signature based image verification
+                    "width": Number,
+                    "height": Number,
+                    "verificationFunction": 'ecdsa',
+                    "verificationData": 'string',  // signer that signed the bytes of the image
+                    "verificationSource": 'string' // e.g url returning the signature of the signed image
+                    "url": 'string'
+                },
+                { // example of a NFT/smart contract based image
+                    "address": Address, // the address of an LSP7 or LSP8
+                    "tokenId": 32bytes  // (optional) if token contract is an LSP7
+                }
                 ...
             ],
             [...]
         ],
         "assets": [ // SHOULD be used for any assets of the token (e.g. 3d assets, high res pictures or music, etc)
             {
-                "hashFunction": 'keccak256(bytes)',
-                "hash": 'string',
+                "verificationFunction": 'keccak256(bytes)',
+                "verificationData": 'string',
                 "url": 'string',
                 "fileType": 'string'
+            },
+            { // example of a NFT/smart contract based asset
+                "address": Address, // the address of an LSP7 or LSP8
+                "tokenId": 32bytes  // (optional) if token contract is an LSP7
             }
         ],
         "attributes": [
@@ -183,8 +211,8 @@ Example:
             {
                 width: 256,
                 height: 256,
-                hashFunction: 'keccak256(bytes)',
-                hash: '0x01299df007997de92a820c6c2ec1cb2d3f5aa5fc1adf294157de563eba39bb6f',
+                verificationFunction: 'keccak256(bytes)',
+                verificationData: '0x01299df007997de92a820c6c2ec1cb2d3f5aa5fc1adf294157de563eba39bb6f',
                 url: 'ifps://QmW5cF4r9yWeY1gUCtt7c6v3ve7Fzdg8CKvTS96NU9Uiwr'
             }
         ],
@@ -193,8 +221,8 @@ Example:
                 {
                     width: 1024,
                     height: 974,
-                    hashFunction: 'keccak256(bytes)',
-                    hash: '0xa9399df007997de92a820c6c2ec1cb2d3f5aa5fc1adf294157de563eba39bb6e',
+                    verificationFunction: 'keccak256(bytes)',
+                    verificationData: '0xa9399df007997de92a820c6c2ec1cb2d3f5aa5fc1adf294157de563eba39bb6e',
                     url: 'ifps://QmW4wM4r9yWeY1gUCtt7c6v3ve7Fzdg8CKvTS96NU9Uiwr'
                 },
                 ... // more image sizes
@@ -202,8 +230,8 @@ Example:
             ... // more images
         ],
         assets: [{
-            hashFunction: 'keccak256(bytes)',
-            hash: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
+            verificationFunction: 'keccak256(bytes)',
+            verificationData: '0x98fe032f81c43426fbcfb21c780c879667a08e2a65e8ae38027d4d61cdfe6f55',
             url: 'ifps://QmPJESHbVkPtSaHntNVY5F6JDLW8v69M2d6khXEYGUMn7N',
             fileType: 'fbx'
         }],

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -129,7 +129,7 @@ The linked JSON file SHOULD have the following format:
                 "width": Number,
                 "height": Number,
                 "verificationFunction": 'keccak256(bytes)',
-                "verificationData": 'string', // bytes32 hex string of the image verificationData
+                "verificationData": 'string', // bytes32 hash of the image
                 "url": 'string'
             },
             { // example of a signature based image verification
@@ -154,7 +154,7 @@ The linked JSON file SHOULD have the following format:
                     "width": Number,
                     "height": Number,
                     "verificationFunction": 'keccak256(bytes)',
-                    "verificationData": 'string', // bytes32 hex string of the image verificationData
+                    "verificationData": 'string', // bytes32 hash of the image
                     "url": 'string'
                 },
                 { // example of a signature based image verification


### PR DESCRIPTION
To allow for more flexible ways to very images and other sources referenced from smart contracts, we should change the property names in LSP3 and LSP4 for images and asset content to `verificationFunction`, `verificationData `

```js
{ // example of a verificationData based image verification
      "width": Number,
      "height": Number,
      "verificationFunction": 'keccak256(bytes)',
      "verificationData": 'string', // bytes32 hash of the image
      "url": 'string'
  },
  { // example of a signature based image verification
      "width": Number,
      "height": Number,
      "verificationFunction": 'ecdsa',
      "verificationData": 'string', // signer that signed the bytes of the image
      "verificationSource": 'string' // e.g url returning the signature of the signed image
      "url": 'string'
  },
```

This way it can also be used to verify server generated NFT images for example, as long as they have a `verificationSource` URL of some kind. One example is signature based verification of content, where the `verificationSource` returns the signed image datas, and the `verificationData` the signer address (could also be a UP address)

I know this is a bit of a change for projects like universal.page.
But this would enable server rendered and verifiable NFTs and other use cases.

Something we won't be able to add once all these tools are live and NFTs got deployed on mainnet