### PR TITLE
Update LSP7 and LSP8 InterfaceId and function signature (Notification Changes)

### DIFF
--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -107,7 +107,7 @@ _Requirements:_
 
 - If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
 
-  - `typeId`: keccak256('LSP7Tokens_OperatorNotification') > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
+  - `typeId`: `keccak256('LSP7Tokens_OperatorNotification')` > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
   - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `amount` (uint256) , and the `operatorNotificationData` (bytes) respectively.
 
 <br>
@@ -135,9 +135,9 @@ _Requirements:_
 
 **LSP1 Hooks:**
 
-- If the notify parameter is set to true, and the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
+- If the `notify` parameter is set to `true`, and the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
 
-  - `typeId`: keccak256('LSP7Tokens_OperatorNotification') > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
+  - `typeId`: `keccak256('LSP7Tokens_OperatorNotification')` > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
   - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `amount` (uint256) (0 in case of revoke), and the `operatorNotificationData` (bytes) respectively.
 
 <br>
@@ -165,7 +165,7 @@ _Requirements:_
 
 - If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
 
-  - `typeId`: keccak256('LSP7Tokens_OperatorNotification') > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
+  - `typeId`: `keccak256('LSP7Tokens_OperatorNotification')` > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
   - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `amount` (uint256) (new allowance) , and the `operatorNotificationData` (bytes) respectively.
 
 <be>
@@ -188,7 +188,7 @@ _Parameters:_
 
 - If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
 
-  - `typeId`: keccak256('LSP7Tokens_OperatorNotification') > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
+  - `typeId`: `keccak256('LSP7Tokens_OperatorNotification')` > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
   - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `amount` (uint256) (new allowance) , and the `operatorNotificationData` (bytes) respectively.
 
 <br>

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -33,7 +33,7 @@ A commonality with [LSP8 IdentifiableDigitalAsset][LSP8] is desired so that the 
 
 ## Specification
 
-[ERC165] interface id: `0x05519512`
+[ERC165] interface id: `0xdaa746b7`
 
 The LSP7 interface ID is calculated as the XOR of the LSP7 interface (see [interface cheat-sheet below](#interface-cheat-sheet)) and the [LSP17 Extendable interface ID](./LSP-17-ContractExtension.md#erc165-interface-id).
 
@@ -103,10 +103,19 @@ _Requirements:_
 - `operator` cannot be calling address.
 - `operator` cannot be the zero address.
 
+**LSP1 Hooks:**
+
+- If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
+
+  - `typeId`: keccak256('LSP7Tokens_OperatorNotification') > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
+  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `amount` (uint256) , and the `operatorNotificationData` (bytes) respectively.
+
+<br>
+
 #### revokeOperator
 
 ```solidity
-function revokeOperator(address operator, bytes memory operatorNotificationData) external;
+function revokeOperator(address operator, bool notify, bytes memory operatorNotificationData) external;
 ```
 
 Removes `operator` address as an operator of callers tokens.
@@ -116,12 +125,69 @@ MUST emit a [RevokedOperator event](#revokedoperator).
 _Parameters:_
 
 - `operator` the address to revoke as an operator.
+- `notify` the boolean indicating whether to notify the operator via LSP1 or not.
 - `operatorNotificationData` the data to send when notifying the operator via LSP1.
 
 _Requirements:_
 
 - `operator` cannot be calling address.
 - `operator` cannot be the zero address.
+
+**LSP1 Hooks:**
+
+- If the notify parameter is set to true, and the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
+
+  - `typeId`: keccak256('LSP7Tokens_OperatorNotification') > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
+  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `amount` (uint256) (0 in case of revoke), and the `operatorNotificationData` (bytes) respectively.
+
+<br>
+
+
+#### increaseAllowance
+
+```solidity
+function increaseAllowance(address operator, uint256 addedAmount, bytes memory operatorNotificationData) external;
+```
+
+Increase the allowance of `operator` by `addedAmount`. This is an alternative approach to {authorizeOperator} that can be used as a mitigation for the double spending allowance problem. Notify the operator based on the LSP1-UniversalReceiver standard.
+
+_Parameters:_
+
+- `operator` the address to increase allowance as an operator.
+- `addedAmount` the amount to add to the existing allowance of tokens operator has access to.
+- `operatorNotificationData` the data to send when notifying the operator via LSP1.
+
+**LSP1 Hooks:**
+
+- If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
+
+  - `typeId`: keccak256('LSP7Tokens_OperatorNotification') > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
+  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `amount` (uint256) (new allowance) , and the `operatorNotificationData` (bytes) respectively.
+
+<be>
+
+#### decreaseAllowance
+
+```solidity
+function decreaseAllowance(address operator, uint256 subtractedAmount, bytes memory operatorNotificationData) external;
+```
+
+Decrease the allowance of `operator` by `subtractedAmount`. This is an alternative approach to {authorizeOperator} that can be used as a mitigation for the double spending allowance problem. Notify the operator based on the LSP1-UniversalReceiver standard.
+
+_Parameters:_
+
+- `operator` the address to decrease allowance as an operator.
+- `subtractedAmount` the amount to substract to the existing allowance of tokens operator has access to.
+- `operatorNotificationData` the data to send when notifying the operator via LSP1.
+
+**LSP1 Hooks:**
+
+- If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
+
+  - `typeId`: keccak256('LSP7Tokens_OperatorNotification') > `0x386072cc5a58e61263b434c722725f21031cd06e7c552cfaa06db5de8a320dbc`
+  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `amount` (uint256) (new allowance) , and the `operatorNotificationData` (bytes) respectively.
+
+<br>
 
 #### authorizedAmountFor
 
@@ -232,7 +298,7 @@ MUST be emitted when `amount` tokens is transferred from `from` to `to`.
 #### AuthorizedOperator
 
 ```solidity
-event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 amount);
+event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 amount, bytes operatorNotificationData);
 ```
 
 MUST be emitted when `tokenOwner` enables `operator` for `amount` tokens.
@@ -240,7 +306,7 @@ MUST be emitted when `tokenOwner` enables `operator` for `amount` tokens.
 #### RevokedOperator
 
 ```solidity
-event RevokedOperator(address indexed operator, address indexed tokenOwner);
+event RevokedOperator(address indexed operator, address indexed tokenOwner, bool notify, bytes memory operatorNotificationData);
 ```
 
 MUST be emitted when `tokenOwner` disables `operator`.
@@ -306,9 +372,9 @@ interface ILSP7 is /* IERC165 */ {
 
     event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data);
 
-    event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 indexed amount);
+    event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 indexed amount, bytes operatorNotificationData);
 
-    event RevokedOperator(address indexed operator, address indexed tokenOwner);
+    event RevokedOperator(address indexed operator, address indexed tokenOwner, bool notify, bytes operatorNotificationData);
 
 
     function decimals() external view returns (uint8);
@@ -319,7 +385,11 @@ interface ILSP7 is /* IERC165 */ {
 
     function authorizeOperator(address operator, uint256 amount, bytes memory operatorNotificationData) external;
 
-    function revokeOperator(address to, bytes memory operatorNotificationData) external;
+    function revokeOperator(address to, bool notify, bytes memory operatorNotificationData) external;
+
+    function increaseAllowance(address operator, uint256 addedAmount, bytes memory operatorNotificationData) external;
+
+    function decreaseAllowance(address operator, uint256 subtractedAmount, bytes memory operatorNotificationData) external;
 
     function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256);
 
@@ -328,6 +398,7 @@ interface ILSP7 is /* IERC165 */ {
     function transfer(address from, address to, uint256 amount, bool force, bytes memory data) external;
 
     function transferBatch(address[] memory from, address[] memory to, uint256[] memory amount, bool force, bytes[] memory data) external;
+    
 }
 
 ```

--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -157,6 +157,10 @@ _Parameters:_
 - `addedAmount` the amount to add to the existing allowance of tokens operator has access to.
 - `operatorNotificationData` the data to send when notifying the operator via LSP1.
 
+_Requirements:_
+
+- `operator`'s original allowance cannot be zero.
+
 **LSP1 Hooks:**
 
 - If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -35,7 +35,7 @@ A commonality with [LSP7 DigitalAsset][LSP7] is desired so that the two token im
 
 ## Specification
 
-[ERC165] interface id: `0x1ae9ba1f`
+[ERC165] interface id: `0x30dc5278`
 
 The LSP8 interface ID is calculated as the XOR of the LSP8 interface (see [interface cheat-sheet below](#interface-cheat-sheet)) and the [LSP17 Extendable interface ID](./LSP-17-ContractExtension.md#erc165-interface-id).
 
@@ -278,10 +278,19 @@ _Requirements:_
 - `operator` cannot be calling address.
 - `operator` cannot be the zero address.
 
+**LSP1 Hooks:**
+
+- If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
+
+  - `typeId`: keccak256('LSP8Tokens_OperatorNotification') > `0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970`
+  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `tokenId` (bytes32), and the `operatorNotificationData` (bytes) respectively.
+
+<br>
+
 #### revokeOperator
 
 ```solidity
-function revokeOperator(address operator, bytes32 tokenId, bytes memory operatorNotificationData) external;
+function revokeOperator(address operator, bytes32 tokenId, bool notify, bytes memory operatorNotificationData) external;
 ```
 
 Removes `operator` address as an operator of `tokenId`.
@@ -300,6 +309,15 @@ _Requirements:_
 - caller must be current `tokenOwner` of `tokenId`.
 - `operator` cannot be calling address.
 - `operator` cannot be the zero address.
+
+**LSP1 Hooks:**
+
+- If the notify boolean is set to true and the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
+
+  - `typeId`: keccak256('LSP8Tokens_OperatorNotification') > `0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970`
+  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `tokenId` (bytes32), and the `operatorNotificationData` (bytes) respectively.
+
+<br>
 
 #### isOperatorFor
 
@@ -424,7 +442,7 @@ MUST be emitted when `tokenId` token is transferred from `from` to `to`.
 #### AuthorizedOperator
 
 ```solidity
-event AuthorizedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId);
+event AuthorizedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId, bytes operatorNotificationData);
 ```
 
 MUST be emitted when `tokenOwner` enables `operator` for `tokenId`.
@@ -432,7 +450,7 @@ MUST be emitted when `tokenOwner` enables `operator` for `tokenId`.
 #### RevokedOperator
 
 ```solidity
-event RevokedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId);
+event RevokedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId, bool notified, bytes operatorNotificationData);
 ```
 
 MUST be emitted when `tokenOwner` disables `operator` for `tokenId`.
@@ -539,9 +557,9 @@ interface ILSP8 is /* IERC165 */ {
 
     event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool force, bytes data);
 
-    event AuthorizedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId);
+    event AuthorizedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId, bytes operatorNotificationData);
 
-    event RevokedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId);
+    event RevokedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId, bool notified, bytes operatorNotificationData);
 
 
     function totalSupply() external view returns (uint256);
@@ -554,7 +572,7 @@ interface ILSP8 is /* IERC165 */ {
 
     function authorizeOperator(address operator, bytes32 tokenId, bytes memory operatorNotificationData) external;
 
-    function revokeOperator(address operator, bytes32 tokenId, bytes memory operatorNotificationData) external;
+    function revokeOperator(address operator, bytes32 tokenId, bool notify, bytes memory operatorNotificationData) external;
 
     function isOperatorFor(address operator, bytes32 tokenId) external view returns (bool);
 

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -283,7 +283,7 @@ _Requirements:_
 - If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
 
   - `typeId`: keccak256('LSP8Tokens_OperatorNotification') > `0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970`
-  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `tokenId` (bytes32), and the `operatorNotificationData` (bytes) respectively.
+  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `tokenId` (bytes32), `isAuthorized` (boolean), and the `operatorNotificationData` (bytes) respectively.
 
 <br>
 
@@ -315,7 +315,7 @@ _Requirements:_
 - If the notify boolean is set to true and the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
 
   - `typeId`: keccak256('LSP8Tokens_OperatorNotification') > `0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970`
-  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `tokenId` (bytes32), and the `operatorNotificationData` (bytes) respectively.
+  - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `tokenId` (bytes32), `isAuthorized` (boolean), and the `operatorNotificationData` (bytes) respectively.
 
 <br>
 

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -282,7 +282,7 @@ _Requirements:_
 
 - If the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
 
-  - `typeId`: keccak256('LSP8Tokens_OperatorNotification') > `0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970`
+  - `typeId`: `keccak256('LSP8Tokens_OperatorNotification')` > `0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970`
   - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `tokenId` (bytes32), `isAuthorized` (boolean), and the `operatorNotificationData` (bytes) respectively.
 
 <br>
@@ -312,9 +312,9 @@ _Requirements:_
 
 **LSP1 Hooks:**
 
-- If the notify boolean is set to true and the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
+- If the `notify` boolean is set to `true` and the operator is a contract that supports LSP1 interface, it SHOULD call operator's [`universalReceiver(...)`] function with the parameters below:
 
-  - `typeId`: keccak256('LSP8Tokens_OperatorNotification') > `0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970`
+  - `typeId`: `keccak256('LSP8Tokens_OperatorNotification')` > `0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970`
   - `data`: The data sent SHOULD be abi encoded and contain the `tokenOwner` (address), `tokenId` (bytes32), `isAuthorized` (boolean), and the `operatorNotificationData` (bytes) respectively.
 
 <br>


### PR DESCRIPTION
- Mark `increaseAllowance` and `decreaseAllowance` as part of the interface resulting in a change of interfaceId in LSP7
- Add boolean parameter to revokeOperator to signal whether to notify or not in LSP7 and LSP8 resulting in interfaceId change.
- Mark the notification in increase/decreaseAllowance and authorizeOperator as mandatory that does revert when the receiver revert. These notifications only occurs in case the operator supports LSP1.


Add missing changes such as parameters in events, etc ..