### PR TITLE
fix: changing JSONURL uses to VerifiableURI in LSP-3-Profile-Metadata.md

### DIFF
--- a/LSPs/LSP-3-Profile-Metadata.md
+++ b/LSPs/LSP-3-Profile-Metadata.md
@@ -51,11 +51,11 @@ A JSON file that describes the profile information, including profile image, bac
   "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
   "keyType": "Singleton",
   "valueType": "bytes",
-  "valueContent": "JSONURL"
+  "valueContent": "VerifiableURI"
 }
 ```
 
-For construction of the JSONURL value see: [ERC725Y JSON Schema](./LSP-2-ERC725YJSONSchema.md#JSONURL)
+For construction of the VerifiableURI value see: [ERC725Y VerifiableURI Schema](./LSP-2-ERC725YJSONSchema.md#VerifiableURI)
 
 The linked JSON file SHOULD have the following format:
 
@@ -219,10 +219,10 @@ or a verifiable public appearance. This metadata does not need to belong to a re
 
 ## Implementation
 
-A implementation can be found in the [lukso-network/universalprofile-smart-contracts](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/blob/main/contracts/UniversalProfile.sol);
+An implementation can be found in the [lukso-network/universalprofile-smart-contracts](https://github.com/lukso-network/lsp-universalprofile-smart-contracts/blob/main/contracts/UniversalProfile.sol);
 The below defines the JSON interface of the `LSP3Profile`.
 
-ERC725Y JSON Schema `LSP3Profile`:
+ERC725Y VerifiableURI Schema `LSP3Profile`:
 
 ```json
 [
@@ -238,7 +238,7 @@ ERC725Y JSON Schema `LSP3Profile`:
     "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
     "keyType": "Singleton",
     "valueType": "bytes",
-    "valueContent": "JSONURL"
+    "valueContent": "VerifiableURI"
   },
   // from LSP12 IssuedAssets
   {

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -585,7 +585,7 @@ The `force` parameter sent during `function transfer` SHOULD be used when notify
 
 <!--The implementations must be completed before any LIP is given status "Final", but it need not be completed before the LIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
 
-A implementation can be found in the [lukso-network/lsp-smart-contracts][lsp8.sol].
+An implementation can be found in the [lukso-network/lsp-smart-contracts][lsp8.sol].
 
 ERC725Y JSON Schema `LSP8IdentifiableDigitalAsset`:
 
@@ -701,9 +701,5 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [erc725y]: https://github.com/ERC725Alliance/ERC725/blob/develop/docs/ERC-725.md#erc725y
 [erc777]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-777.md
 [lsp1]: ./LSP-1-UniversalReceiver.md
-[lsp2#jsonurl]: ./LSP-2-ERC725YJSONSchema.md#JSONURL
-[lsp2#mapping]: ./LSP-2-ERC725YJSONSchema.md#mapping
-[lsp4#erc725ykeys]: ./LSP-4-DigitalAsset-Metadata.md#erc725ykeys
 [lsp7]: ./LSP-7-DigitalAsset.md
-[lsp8]: ./LSP-8-IdentifiableDigitalAsset.md
 [lsp8.sol]: https://github.com/lukso-network/lsp-universalprofile-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol


### PR DESCRIPTION
Updated LSP3 to use VerifiableURI instead of JSONURL.

It doesn't seem that we need to change anything else since those schemas have `keyType` Singleton. `key` value stays the same.