### PR TITLE
[M-01] transferBatch() is declared wrongly in the LSP7 and LSP8 specification

### DIFF
--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -282,7 +282,7 @@ _Requirements:_
 #### transferBatch
 
 ```solidity
-function transferBatch(address[] memory from, address[] memory to, uint256[] memory amount, bool force, bytes[] memory data) external;
+function transferBatch(address[] memory from, address[] memory to, uint256[] memory amount, bool[] memory force, bytes[] memory data) external;
 ```
 
 Transfers many tokens based on the list `from`, `to`, `amount`. If any transfer fails, the call will revert.

--- a/LSPs/LSP-8-IdentifiableDigitalAsset.md
+++ b/LSPs/LSP-8-IdentifiableDigitalAsset.md
@@ -270,7 +270,7 @@ _Requirements:_
 #### transferBatch
 
 ```solidity
-function transferBatch(address[] memory from, address[] memory to, bytes32[] memory tokenId, bool force, bytes[] memory data) external;
+function transferBatch(address[] memory from, address[] memory to, bytes32[] memory tokenId, bool[] memory force, bytes[] memory data) external;
 ```
 
 Transfers many tokens based on the list `from`, `to`, `tokenId`. If any transfer fails, the call will revert.


### PR DESCRIPTION
## What does this PR introduce ?

- Add missing arrays for bool parameter in `transferBatch(..)` in LSP7 and LSP8