### PR TITLE
[L-06] revokeOperator() does not protect against the double-spending allowance attack

### DIFF
--- a/LSPs/LSP-7-DigitalAsset.md
+++ b/LSPs/LSP-7-DigitalAsset.md
@@ -103,7 +103,7 @@ function authorizeOperator(address operator, uint256 amount, bytes memory operat
 
 Sets `amount` as the amount of tokens `operator` address has access to from callers tokens.
 
-To increase or decrease the authorized amount of an operator, it's advised to call `revokeOperator(..)` function first, and then call `authorizeOperator(..)` with the new amount to authorize, to avoid front-running through an allowance double-spend exploit.
+To increase or decrease the authorized amount of an operator, it's advised to call `increaseAllowance(..)`/`decreaseAllowance(..)` function with the added/subtracted amount, to avoid front-running through an allowance double-spend exploit.
 Check more information [in this document](https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/).
 
 MUST emit an [OperatorAuthorizationChanged event](#OperatorAuthorizationChanged).


### PR DESCRIPTION
## What does this PR introduce ?

- Remove recommendation of revokeOperator then authorizeOperator
- Advise use of increase/decrease Allowance in LSP7