### PR TITLE
fix: outdated links for lsp-smart-contracts replaced with new ones

### DIFF
--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -803,7 +803,7 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [LSP10-ReceivedVaults]: ./LSP-10-ReceivedVaults.md
 [LSP6-KeyManager]: ./LSP-6-KeyManager.md
 [LSP14-Ownable2Step]: ./LSP-14-Ownable2Step.md
-[lukso-network/lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts/tree/develop/packages/lsp20-contracts/contracts/LSP0ERC725AccountCore.sol
+[lukso-network/lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts/tree/develop/packages/lsp0-contracts/contracts/LSP0ERC725AccountCore.sol
 [LSP17-ContractExtension]: ./LSP-17-ContractExtension.md
 [LSP20-CallVerification]: ./LSP-20-CallVerification.md
 [`lsp20VerifyCall(..)`]: ./LSP-20-CallVerification.md#lsp20verifycall

--- a/LSPs/LSP-0-ERC725Account.md
+++ b/LSPs/LSP-0-ERC725Account.md
@@ -803,7 +803,7 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [LSP10-ReceivedVaults]: ./LSP-10-ReceivedVaults.md
 [LSP6-KeyManager]: ./LSP-6-KeyManager.md
 [LSP14-Ownable2Step]: ./LSP-14-Ownable2Step.md
-[lukso-network/lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+[lukso-network/lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts/tree/develop/packages/lsp20-contracts/contracts/LSP0ERC725AccountCore.sol
 [LSP17-ContractExtension]: ./LSP-17-ContractExtension.md
 [LSP20-CallVerification]: ./LSP-20-CallVerification.md
 [`lsp20VerifyCall(..)`]: ./LSP-20-CallVerification.md#lsp20verifycall

--- a/LSPs/LSP-1-UniversalReceiver.md
+++ b/LSPs/LSP-1-UniversalReceiver.md
@@ -336,4 +336,4 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [ERC223]: https://github.com/ethereum/EIPs/issues/223
 [ERC777]: https://eips.ethereum.org/EIPS/eip-777
 [specification for the abi-encoding of `bytes`]: https://docs.soliditylang.org/en/v0.8.19/abi-spec.html#formal-specification-of-the-encoding
-[lukso-network/lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts/tree/develop/contracts/LSP1UniversalReceiver
+[lukso-network/lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts/tree/develop/packages/lsp1-contracts/contracts

--- a/LSPs/LSP-11-BasicSocialRecovery.md
+++ b/LSPs/LSP-11-BasicSocialRecovery.md
@@ -284,7 +284,7 @@ In this case, it is ensured that guardians can't act maliciously and would need 
 
 ## Implementation
 
-An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/pull/114) repository.
+An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/packages/lsp-smart-contracts/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryCore.sol) repository.
 
 ## Interface Cheat Sheet
 

--- a/LSPs/LSP-16-UniversalFactory.md
+++ b/LSPs/LSP-16-UniversalFactory.md
@@ -735,7 +735,7 @@ Furthermore, if a contract is not initializable, the provided salt is hashed to 
 
 ## Implementation
 
-An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP16UniversalFactory/LSP16UniversalFactory.sol) repository.
+An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/packages/lsp16-contracts/contracts/LSP16UniversalFactory.sol) repository.
 
 ## Security Consideration
 
@@ -751,5 +751,5 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [CREATE2]: https://eips.ethereum.org/EIPS/eip-1014
 [minimal proxy]: https://eips.ethereum.org/EIPS/eip-1167
 [ContractCreated]: ./LSP-16-UniversalFactory.md#contractcreated
-[LSP16 UniversalFactory smart contract]: https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP16UniversalFactory/LSP16UniversalFactory.sol
+[LSP16 UniversalFactory smart contract]: https://github.com/lukso-network/lsp-smart-contracts/blob/develop/packages/lsp16-contracts/contracts/LSP16UniversalFactory.sol
 [Nick Factory]: https://github.com/Arachnid/deterministic-deployment-proxy

--- a/LSPs/LSP-17-ContractExtension.md
+++ b/LSPs/LSP-17-ContractExtension.md
@@ -208,7 +208,7 @@ In addition to adding new functionalities, it is crucial to extend the interface
 
 ## Implementation
 
-An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP17ContractExtension/) repository.
+An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/tree/develop/packages/lsp17-contracts/contracts) repository.
 
 ## Copyright
 

--- a/LSPs/LSP-20-CallVerification.md
+++ b/LSPs/LSP-20-CallVerification.md
@@ -156,4 +156,4 @@ interface ILSP20  /* is ERC165 */ {
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-[lukso-network/lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/
+[lukso-network/lsp-smart-contracts]: https://github.com/lukso-network/lsp-smart-contracts/tree/develop/packages

--- a/LSPs/LSP-23-LinkedContractsFactory.md
+++ b/LSPs/LSP-23-LinkedContractsFactory.md
@@ -540,7 +540,7 @@ _Parameters:_
 
 ## Implementation
 
-An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP23LinkedContractsDeployment/LSP23LinkedContractsFactory.sol)
+An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/packages/lsp23-contracts/contracts/LSP23LinkedContractsFactory.sol)
 
 ## Interface Cheat Sheet
 

--- a/LSPs/LSP-4-DigitalAsset-Metadata.md
+++ b/LSPs/LSP-4-DigitalAsset-Metadata.md
@@ -393,7 +393,7 @@ This reliance on a link-based approach, rather than content-based, means that th
 
 ## Implementation
 
-An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol) repository where token contract can inherit the following contract to have access to the ERC725Y storage and have the asset information set automatically.
+An implementation can be found in the [lukso-network/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/packages/lsp4-contracts/contracts/LSP4DigitalAssetMetadataCore.sol) repository where token contract can inherit the following contract to have access to the ERC725Y storage and have the asset information set automatically.
 
 The below defines the JSON interface of the `LSP4DigitalAssetMetadata`.
 

--- a/LSPs/LSP-9-Vault.md
+++ b/LSPs/LSP-9-Vault.md
@@ -495,7 +495,7 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [LSP1]: <./LSP-1-UniversalReceiver.md>
 [LSP2-ERC725YJSONSchema]: <./LSP-2-ERC725YJSONSchema.md>
 [LSP14]: <./LSP-14-Ownable2Step.md>
-[lukso-network/lsp-smart-contracts]: <https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP9Vault/LSP9VaultCore.sol>
+[lukso-network/lsp-smart-contracts]: <https://github.com/lukso-network/lsp-smart-contracts/blob/develop/packages/lsp9-contracts/contracts/LSP9VaultCore.sol>
 [LSP17]: <./LSP-17-ContractExtension.md>
 [LSP17-ContractExtension]: <./LSP-17-ContractExtension.md>
 [UniversalReceiver]: <./LSP-1-UniversalReceiver.md#events>


### PR DESCRIPTION
Noticed that old links to smart contract implementation were no longer working.